### PR TITLE
Hashtags update

### DIFF
--- a/analyzers/hashtags/interface.py
+++ b/analyzers/hashtags/interface.py
@@ -10,8 +10,9 @@ COL_AUTHOR_ID = "user_id"
 COL_TIME = "time"
 COL_HASHTAGS = "hashtags"
 
+OUTPUT_COL_USERS = "users"
 OUTPUT_GINI = "gini_coef"
-OUTPUT_COL_TIMESPAN = "time_span"
+OUTPUT_COL_TIMESPAN = "timewindow_start"
 OUTPUT_COL_GINI = "gini"
 OUTPUT_COL_COUNT = "count"
 OUTPUT_COL_HASHTAGS = COL_HASHTAGS
@@ -19,7 +20,7 @@ OUTPUT_COL_HASHTAGS = COL_HASHTAGS
 interface = AnalyzerInterface(
     id="hashtags",
     version="0.1.0",
-    name="hashtags",
+    name="Hashtags analysis",
     short_description="Computes the gini coefficient over hashtag usage",
     long_description="""
     Analysis of hashtags measures the extent of online coordination among social media users
@@ -81,6 +82,7 @@ interface = AnalyzerInterface(
             name="Gini coefficient over time",
             columns=[
                 OutputColumn(name=OUTPUT_COL_TIMESPAN, data_type="datetime"),
+                OutputColumn(name=OUTPUT_COL_USERS, data_type="text"),
                 OutputColumn(name=OUTPUT_COL_GINI, data_type="float"),
                 OutputColumn(name=OUTPUT_COL_COUNT, data_type="integer"),
                 OutputColumn(name=OUTPUT_COL_HASHTAGS, data_type="text"),

--- a/analyzers/hashtags/main.py
+++ b/analyzers/hashtags/main.py
@@ -93,10 +93,6 @@ def hashtag_analysis(data_frame:pl.DataFrame, every="1h") -> pl.DataFrame:
                 gini, returns_scalar=True
             ).alias(OUTPUT_COL_GINI)
         )
-        .with_columns(
-            pl.col(OUTPUT_COL_USERS).list.join(", ").alias(OUTPUT_COL_USERS),
-            pl.col(OUTPUT_COL_HASHTAGS).list.join(", ").alias(OUTPUT_COL_HASHTAGS)
-        )
     )
 
     return df_out

--- a/analyzers/hashtags/main.py
+++ b/analyzers/hashtags/main.py
@@ -42,36 +42,45 @@ def gini(x):
     return (n + 1 - 2 * sum(cumx) / cumx[-1]) / n
 
 
-def main(context: PrimaryAnalyzerContext):
+def hashtag_analysis(data_frame:pl.DataFrame, every="1h") -> pl.DataFrame:
 
-    input_reader = context.input()
-    df_input = input_reader.preprocess(pl.read_parquet(input_reader.parquet_path))
+    has_hashtag_symbol = pl.col(COL_HASHTAGS).str.contains("#").any()
+    extract_hashtags = pl.col(COL_HASHTAGS).str.extract_all(r'(#\S+)')
+    extract_hashtags_by_split = (
+        pl.col(COL_HASHTAGS)
+        .str.strip_chars("[]")
+        .str.replace_all("'", "")
+        .str.replace_all(" ", "")
+        .str.split(",")
+        )
 
     # assign None to messages with no hashtags
-    df_input = df_input.with_columns(
-        pl.when(pl.col(COL_HASHTAGS) == NULL_CHAR)
-        .then(None)
-        .otherwise(
-            pl.col(COL_HASHTAGS)
-            .str.strip_chars("[]")
-            .str.replace_all("'", "")
-            .str.replace_all(" ", "")
-            .str.split(",")
-        )  # split hashtags into List[str]
-        .name.keep()
-    )
+    if data_frame.select(has_hashtag_symbol).item():
+        df_input = (
+            data_frame
+            .with_columns(extract_hashtags)
+            .filter(pl.col(COL_HASHTAGS) != [])
+        )
+    else:
+        df_input = (
+            data_frame
+            .filter(pl.col(COL_HASHTAGS) == '[]')
+            .with_columns(extract_hashtags_by_split)
+        )
 
     # select columns
     df_input = df_input.select(pl.col(COLS_ALL))
 
+    breakpoint()
+
     df_agg = (
-        df_input.filter(pl.col(COL_HASHTAGS).is_not_null())
+        df_input.drop_nulls(pl.col(COL_HASHTAGS))
         .select(
             pl.col(COL_TIME),
             pl.col(COL_HASHTAGS),
         )
         .sort(COL_TIME)
-        .group_by_dynamic(COL_TIME, every="1h")  # this could be a parameter
+        .group_by_dynamic(COL_TIME, every=every)  # this could be a parameter
         .agg(
             pl.col(COL_HASHTAGS).explode().alias(OUTPUT_COL_HASHTAGS),
             pl.col(COL_HASHTAGS).explode().count().alias(OUTPUT_COL_COUNT),
@@ -86,7 +95,15 @@ def main(context: PrimaryAnalyzerContext):
         )
     )
 
-    print("Output preview:")
-    print(df_agg.head())
+    return df_agg
+
+def main(context: PrimaryAnalyzerContext):
+
+    input_reader = context.input()
+    df_input = input_reader.preprocess(pl.read_parquet(input_reader.parquet_path))
+
+    df_agg = hashtag_analysis(
+        data_frame=df_input,
+    )
 
     df_agg.write_parquet(context.output(OUTPUT_GINI).parquet_path)


### PR DESCRIPTION
This is a WIP PR relating to #104 and ads the following (making the analyzer a bit more flexible):

- the analyzer checks  if a `#` symbol is present in the post text column (e.g. `"We need more mangos #mango # fruits"`) and extracts all the words following the symbol 
- otherwise it expects a separate column with pre-extracted hashtags formatted as string: `"['mangos', 'fruits']"`
- `gini()` function now operates on pl.Series not python list
- analyzer function uses `map_batches()`, not `.map_elements()`
- ads `hashtags` and `users` columns to primary output (both `list[str]`) --> useful for secondary analyses (e.g. what are most frequent hashtags time windows when gini is high?)
- some refactoring

### To do

- [ ] currently exports only work for .json (can't write nested columns to .csv)
- [ ] add tests (relates to #105)