### PR TITLE
test: 💍 expose CsvConfig for CsvTestData

### DIFF
--- a/analyzers/example/test_example_base.py
+++ b/analyzers/example/test_example_base.py
@@ -1,7 +1,7 @@
 import os
 
 from preprocessing.series_semantic import identifier
-from testing import CsvTestData, test_primary_analyzer
+from testing import CsvTestData, CsvConfig, test_primary_analyzer
 
 from .example_base.interface import interface
 from .example_base.main import main
@@ -28,6 +28,14 @@ def test_example_base():
             # JsonTestData if you have data that need to be interpreted into
             # types not directly supported by the file format like timestamp.
             semantics={"message_id": identifier},
+            # This is optional; it lets you specify how the CSV file is read.
+            # Every field in this is optional, too. These are the defaults.
+            csv_config=CsvConfig(
+                has_header=True,
+                quote_char='"',
+                encoding="utf8",
+                separator=",",
+            ),
         ),
         # These outputs are the expected outputs of the analyzer.
         # You don't need to specify all the outputs, only the ones you want to test.

--- a/analyzers/example/test_example_base.py
+++ b/analyzers/example/test_example_base.py
@@ -1,7 +1,7 @@
 import os
 
 from preprocessing.series_semantic import identifier
-from testing import CsvTestData, CsvConfig, test_primary_analyzer
+from testing import CsvConfig, CsvTestData, test_primary_analyzer
 
 from .example_base.interface import interface
 from .example_base.main import main

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -1,2 +1,8 @@
-from .testdata import CsvTestData, ExcelTestData, JsonTestData, PolarsTestData
+from .testdata import (
+    CsvTestData,
+    CsvConfig,
+    ExcelTestData,
+    JsonTestData,
+    PolarsTestData,
+)
 from .testers import test_primary_analyzer, test_secondary_analyzer

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -1,6 +1,6 @@
 from .testdata import (
-    CsvTestData,
     CsvConfig,
+    CsvTestData,
     ExcelTestData,
     JsonTestData,
     PolarsTestData,

--- a/testing/testdata.py
+++ b/testing/testdata.py
@@ -78,10 +78,22 @@ class CsvTestData(TestData):
         super().__init__(filepath=filepath, semantics=semantics, csv_config=csv_config)
 
     def _load_as_polars(self) -> pl.DataFrame:
-        return pl.read_csv(self.filepath)
+        return pl.read_csv(
+            self.filepath,
+            separator=self.csv_config.separator,
+            has_header=self.csv_config.has_header,
+            quote_char=self.csv_config.quote_char,
+            encoding=self.csv_config.encoding,
+        )
 
     def _scan_as_polars(self) -> pl.LazyFrame:
-        return pl.scan_csv(self.filepath)
+        return pl.scan_csv(
+            self.filepath,
+            separator=self.csv_config.separator,
+            has_header=self.csv_config.has_header,
+            quote_char=self.csv_config.quote_char,
+            encoding=self.csv_config.encoding,
+        )
 
 
 class JsonTestData(FileTestData):


### PR DESCRIPTION
The `CsvConfig` class encodes how CSV files can be loaded for testing, but it was never exposed or wired up in the `CsvTestData` file. This commit corrects this, and adds an example of how to use it to customize the way test CSV files are loaded for testing. This should aid the customization required for #107.