### PR TITLE
Opendirectoryscreen copyupdate

### DIFF
--- a/app/analysis_context.py
+++ b/app/analysis_context.py
@@ -1,3 +1,4 @@
+import os
 from functools import cached_property
 from tempfile import TemporaryDirectory
 from typing import Literal
@@ -126,6 +127,9 @@ class AnalysisContext(BaseModel):
     @property
     def export_root_path(self):
         return self.app_context.storage._get_project_exports_root_path(self.model)
+
+    def export_directory_exists(self) -> bool:
+        return os.path.exists(self.export_root_path)
 
     def get_all_exportable_outputs(self):
         from .analysis_output_context import AnalysisOutputContext

--- a/components/analysis_main.py
+++ b/components/analysis_main.py
@@ -34,13 +34,13 @@ def analysis_main(
                     ),
                     *(
                         [
-                            ("Export outputs", "export_output"),
+                            ("Export raw output files", "export_output"),
                         ]
                         if not is_draft
                         else []
                     ),
                     *(
-                        [("Launch Web Server", "web_server")]
+                        [("Initiate browser-based dashboard", "web_server")]
                         if (not is_draft) and has_web_server and not no_web_server
                         else []
                     ),

--- a/components/analysis_main.py
+++ b/components/analysis_main.py
@@ -60,7 +60,6 @@ def analysis_main(
             continue
 
         if action == "export_output":
-            print(context)
             export_outputs(context, analysis)
             continue
 

--- a/components/analysis_main.py
+++ b/components/analysis_main.py
@@ -7,11 +7,14 @@ from .context import ViewContext
 from .export_outputs import export_outputs
 
 
-def analysis_main(context: ViewContext, analysis: AnalysisContext):
+def analysis_main(
+    context: ViewContext, analysis: AnalysisContext, *, no_web_server=False
+):
     terminal = context.terminal
     while True:
         has_web_server = len(analysis.web_presenters) > 0
         is_draft = analysis.is_draft
+        has_exports = analysis.export_directory_exists()
 
         with terminal.nest(
             draw_box(f"Analysis: {analysis.display_name}", padding_lines=0)
@@ -25,6 +28,12 @@ def analysis_main(context: ViewContext, analysis: AnalysisContext):
                     *(
                         [
                             ("Open output directory", "open_output_dir"),
+                        ]
+                        if has_exports
+                        else []
+                    ),
+                    *(
+                        [
                             ("Export outputs", "export_output"),
                         ]
                         if not is_draft
@@ -32,7 +41,7 @@ def analysis_main(context: ViewContext, analysis: AnalysisContext):
                     ),
                     *(
                         [("Launch Web Server", "web_server")]
-                        if (not is_draft) and has_web_server
+                        if (not is_draft) and has_web_server and not no_web_server
                         else []
                     ),
                     ("Rename", "rename"),
@@ -51,6 +60,7 @@ def analysis_main(context: ViewContext, analysis: AnalysisContext):
             continue
 
         if action == "export_output":
+            print(context)
             export_outputs(context, analysis)
             continue
 

--- a/components/analysis_web_server.py
+++ b/components/analysis_web_server.py
@@ -67,7 +67,7 @@ def analysis_web_server(
             analyzer_name=analyzer.name,
         )
 
-    print("Web server will run at http://localhost:8050/")
+    print("View the analytics dashboard: http://localhost:8050/")
     print("Stop it with Ctrl+C")
 
     server_log = logging.getLogger("waitress")

--- a/components/export_outputs.py
+++ b/components/export_outputs.py
@@ -14,6 +14,7 @@ from .context import ViewContext
 
 
 def export_outputs(context: ViewContext, analysis: AnalysisContext):
+    print(context)
     terminal = context.terminal
     with terminal.nest("[Export Output]\n\n") as scope:
         outputs = sorted(

--- a/components/new_analysis.py
+++ b/components/new_analysis.py
@@ -14,7 +14,7 @@ from app import ProjectContext
 from terminal_tools import draw_box, print_ascii_table, prompts, wait_for_key
 
 from .context import ViewContext
-#from .export_outputs import export_format_prompt, export_outputs_sequence
+from .export_outputs import export_format_prompt, export_outputs_sequence
 
 
 def new_analysis(
@@ -203,16 +203,8 @@ def new_analysis(
 
                 run_scope.refresh()
                 print("<<Hit Ctrl+C at any time to exit a menu>>")
-                print("The test is complete.")
-                print("")
-                print("Name the analysis below. Hit enter to continue.")
-                new_name = (
-                    prompts.text("Analysis name", default=analyzer.name) or ""
-                ).strip()
-                if new_name:
-                    analysis.rename(new_name)
-
-                print("")
+                print("The Analysis is complete.")
+                wait_for_key(prompt=True)
 
                 return analysis
 

--- a/components/new_analysis.py
+++ b/components/new_analysis.py
@@ -14,7 +14,7 @@ from app import ProjectContext
 from terminal_tools import draw_box, print_ascii_table, prompts, wait_for_key
 
 from .context import ViewContext
-from .export_outputs import export_format_prompt, export_outputs_sequence
+#from .export_outputs import export_format_prompt, export_outputs_sequence
 
 
 def new_analysis(
@@ -213,22 +213,6 @@ def new_analysis(
                     analysis.rename(new_name)
 
                 print("")
-
-                outputs = analysis.get_all_exportable_outputs()
-                print("You now have the option to export the following outputs:")
-                for output in outputs:
-                    print("- " + output.descriptive_qualified_name)
-                print("")
-
-                export_format = export_format_prompt()
-                if export_format is None:
-                    print(
-                        "No problem. You can also export outputs later from the analysis menu."
-                    )
-                    wait_for_key(True)
-                else:
-                    is_export_started = True
-                    export_outputs_sequence(context, analysis, outputs, export_format)
 
                 return analysis
 


### PR DESCRIPTION
This PR stems from the CLI Update: ngramopendirectory screen #99 issue. The issue turned out to be more than a copy update requiring changes to the cli flow. I consulted @sandytribal and @soul-codes for how best to implement this change. Instead of asking the user to handle exporting the analysis files immediately after a test runs we instead show them this screen:
![image](https://github.com/user-attachments/assets/fec47486-7111-4360-a23b-8fba342b49a9)
This is the main analysis screen, which is now aware of if a user has exported the files yet. 