### PR TITLE
Added json and excel (xlsx, xls) support for imports

### DIFF
--- a/importing/__init__.py
+++ b/importing/__init__.py
@@ -1,4 +1,6 @@
 from .csv import CSVImporter
+from .json import JSONImporter
+from .excel import ExcelImporter
 from .importer import Importer, ImporterSession
 
-importers: list[Importer[ImporterSession]] = [CSVImporter()]
+importers: list[Importer[ImporterSession]] = [CSVImporter(), JSONImporter(), ExcelImporter()]

--- a/importing/excel.py
+++ b/importing/excel.py
@@ -1,0 +1,34 @@
+import polars as pl
+from pydantic import BaseModel
+from .importer import Importer, ImporterSession
+
+class ExcelImporter(Importer["ExcelImportSession"]):
+    @property
+    def name(self) -> str:
+        return "Excel"
+
+    def suggest(self, input_path: str) -> bool:
+        return input_path.endswith(".xlsx") or input_path.endswith(".xls")
+
+    def init_session(self, input_path: str):
+        return ExcelImportSession(input_file=input_path)
+
+    def manual_init_session(self, input_path: str):
+        return ExcelImportSession(input_file=input_path)
+
+    def modify_session(self, input_path: str, import_session: "ExcelImportSession", reset_screen):
+        return import_session
+
+class ExcelImportSession(ImporterSession, BaseModel):
+    input_file: str
+    sheet_name: str = "Sheet1"
+
+    def print_config(self):
+        print(f"- Excel file: {self.input_file}\n- Sheet: {self.sheet_name}")
+
+    def load_preview(self, n_records: int) -> pl.DataFrame:
+        return pl.read_excel(self.input_file, sheet_name=self.sheet_name).head(n_records)
+
+    def import_as_parquet(self, output_path: str) -> None:
+        df = pl.read_excel(self.input_file, sheet_name=self.sheet_name)
+        df.write_parquet(output_path)

--- a/importing/json.py
+++ b/importing/json.py
@@ -1,0 +1,33 @@
+import polars as pl
+from pydantic import BaseModel
+from .importer import Importer, ImporterSession
+
+class JSONImporter(Importer["JsonImportSession"]):
+    @property
+    def name(self) -> str:
+        return "JSON"
+
+    def suggest(self, input_path: str) -> bool:
+        return input_path.endswith(".json")
+
+    def init_session(self, input_path: str):
+        return JsonImportSession(input_file=input_path)
+
+    def manual_init_session(self, input_path: str):
+        return JsonImportSession(input_file=input_path)
+
+    def modify_session(self, input_path: str, import_session: "JsonImportSession", reset_screen):
+        return import_session
+
+class JsonImportSession(ImporterSession, BaseModel):
+    input_file: str
+
+    def print_config(self):
+        print(f"- JSON file: {self.input_file}")
+
+    def load_preview(self, n_records: int) -> pl.DataFrame:
+        return pl.read_json(self.input_file).head(n_records)
+
+    def import_as_parquet(self, output_path: str) -> None:
+        df = pl.read_json(self.input_file)
+        df.write_parquet(output_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyarrow==17.0.0
 dash==2.18.1
 waitress==3.0.0
 colorama==0.4.6
+fastexcel==0.13.0


### PR DESCRIPTION
Added json and excel importers to address [issue 102](https://github.com/civictechdc/mango-tango-cli/issues/102). The Polars function `read_excel()` uses [fastexcel](https://github.com/ToucanToco/fastexcel), which was added to requirements.txt.

The excel importer assumes the sheet to be imported is named "Sheet1". This should be changed in the future to allow the user to choose which sheet to import.

Tested with the sample reddit_vm.csv data set converted to .json and .xlsx