### PR TITLE
feat: analyzer parameterization

### DIFF
--- a/analyzer_interface/__init__.py
+++ b/analyzer_interface/__init__.py
@@ -9,10 +9,19 @@ from .interface import (
     AnalyzerInput,
     AnalyzerInterface,
     AnalyzerOutput,
+    AnalyzerParam,
     DataType,
     InputColumn,
     OutputColumn,
     SecondaryAnalyzerInterface,
     WebPresenterInterface,
+    backfill_param_values,
+)
+from .params import (
+    IntegerParam,
+    ParamType,
+    ParamValue,
+    TimeBinningParam,
+    TimeBinningValue,
 )
 from .suite import AnalyzerSuite

--- a/analyzer_interface/context.py
+++ b/analyzer_interface/context.py
@@ -6,6 +6,7 @@ from dash import Dash
 from pydantic import BaseModel
 
 from .interface import SecondaryAnalyzerInterface
+from .params import ParamValue
 
 
 class PrimaryAnalyzerContext(ABC, BaseModel):
@@ -22,6 +23,14 @@ class PrimaryAnalyzerContext(ABC, BaseModel):
 
         **Note that this is in function form** even though one input is expected,
         in anticipation that we may want to support multiple inputs in the future.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def params(self) -> dict[str, ParamValue]:
+        """
+        Gets the analysis parameters.
         """
         pass
 
@@ -43,6 +52,14 @@ class BaseDerivedModuleContext(ABC, BaseModel):
   Gets the temporary directory that the module can freely write content to
   during its lifetime. This directory will not persist between runs.
   """
+
+    @property
+    @abstractmethod
+    def base_params(self) -> dict[str, ParamValue]:
+        """
+        Gets the primary analysis parameters.
+        """
+        pass
 
     @property
     @abstractmethod

--- a/analyzer_interface/declaration.py
+++ b/analyzer_interface/declaration.py
@@ -10,10 +10,12 @@ from .interface import (
     SecondaryAnalyzerInterface,
     WebPresenterInterface,
 )
+from .params import ParamValue
 
 
 class AnalyzerDeclaration(AnalyzerInterface):
     entry_point: Callable[[PrimaryAnalyzerContext], None]
+    default_params: Callable[[PrimaryAnalyzerContext], dict[str, ParamValue]]
     is_distributed: bool
 
     def __init__(
@@ -21,7 +23,10 @@ class AnalyzerDeclaration(AnalyzerInterface):
         interface: AnalyzerInterface,
         main: Callable,
         *,
-        is_distributed: bool = False
+        is_distributed: bool = False,
+        default_params: Callable[[PrimaryAnalyzerContext], dict[str, ParamValue]] = (
+            lambda _: dict()
+        )
     ):
         """Creates a primary analyzer declaration
 
@@ -39,7 +44,10 @@ class AnalyzerDeclaration(AnalyzerInterface):
             executable.
         """
         super().__init__(
-            **interface.model_dump(), entry_point=main, is_distributed=is_distributed
+            **interface.model_dump(),
+            entry_point=main,
+            default_params=default_params,
+            is_distributed=is_distributed
         )
 
 

--- a/analyzer_interface/params.py
+++ b/analyzer_interface/params.py
@@ -1,0 +1,92 @@
+from typing import Literal, Union
+
+from pydantic import BaseModel, ConfigDict
+
+TimeBinningUnit = Literal[
+    "year",
+    "month",
+    "week",
+    "day",
+    "hour",
+    "minute",
+    "second",
+]
+
+
+class IntegerParam(BaseModel):
+    """
+    Represents an integer value
+
+    The corresponding value will be of type `int`.
+    """
+
+    type: Literal["integer"] = "integer"
+    min: int
+    max: int
+
+
+class TimeBinningParam(BaseModel):
+    """
+    Represents a time bin.
+
+    The corresponding value will be of type `TimeBinningValue`.
+    """
+
+    type: Literal["time_binning"] = "time_binning"
+
+
+class TimeBinningValue(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    unit: TimeBinningUnit
+    amount: int
+
+    def to_polars_truncate_spec(self) -> str:
+        """
+        Converts the value to a string that can be used in Polars truncate spec.
+        See https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.dt.truncate.html
+        """
+        amount = self.amount
+        unit = self.unit
+        if unit == "year":
+            return f"{amount}y"
+        if unit == "month":
+            return f"{amount}mo"
+        if unit == "week":
+            return f"{amount}w"
+        if unit == "day":
+            return f"{amount}d"
+        if unit == "hour":
+            return f"{amount}h"
+        if unit == "minute":
+            return f"{amount}m"
+        if unit == "second":
+            return f"{amount}s"
+
+        raise ValueError("Invalid time binning value")
+
+    def to_human_readable_text(self) -> str:
+        amount = self.amount
+        unit = self.unit
+
+        if unit == "year":
+            return f"{amount} year{'s' if amount > 1 else ''}"
+        if unit == "month":
+            return f"{amount} month{'s' if amount > 1 else ''}"
+        if unit == "week":
+            return f"{amount} week{'s' if amount > 1 else ''}"
+        if unit == "day":
+            return f"{amount} day{'s' if amount > 1 else ''}"
+        if unit == "hour":
+            return f"{amount} hour{'s' if amount > 1 else ''}"
+        if unit == "minute":
+            return f"{amount} minute{'s' if amount > 1 else ''}"
+        if unit == "second":
+            return f"{amount} second{'s' if amount > 1 else ''}"
+
+        raise ValueError("Invalid time binning value")
+
+
+ParamType = Union[TimeBinningParam, IntegerParam]
+
+ParamValue = Union[TimeBinningValue, int]

--- a/analyzers/example/example_base/__init__.py
+++ b/analyzers/example/example_base/__init__.py
@@ -1,5 +1,6 @@
 from analyzer_interface import AnalyzerDeclaration
 
+from .default_params import default_params
 from .interface import interface
 from .main import main
 
@@ -8,6 +9,13 @@ from .main import main
 example_base = AnalyzerDeclaration(
     interface=interface,
     main=main,
+    # Optional.
+    # If your analyzer is parameterized, you can define a function to suggest
+    # default analysis parameters based on the input data. For an easier way
+    # to provide default parameter values independently of input data, simply
+    # specify it in the analysis parameter specification in the interface itself
+    # (see `interface.py`)
+    default_params=default_params,
     # This marks the analyzer as distributed or not. A distributed
     # analyzer is visible only when the application is packaged. A non-distributed
     # analyzer is also visible when the application is run in development mode.

--- a/analyzers/example/example_base/default_params.py
+++ b/analyzers/example/example_base/default_params.py
@@ -1,0 +1,12 @@
+from analyzer_interface import ParamValue
+from analyzer_interface.context import PrimaryAnalyzerContext
+
+
+def default_params(context: PrimaryAnalyzerContext) -> dict[str, ParamValue]:
+    # Like the `main.py` analyzer entry point, the default parameter function
+    # can use the context object to access the input data. It can then use it to
+    # suggest parameters in a data-dependent manner.
+    #
+    # Data-dependent defaults override static defaults. Importantly, if you pass
+    # `None` here, it will *unset* a static default.
+    return {}

--- a/analyzers/example/example_base/interface.py
+++ b/analyzers/example/example_base/interface.py
@@ -2,7 +2,9 @@ from analyzer_interface import (
     AnalyzerInput,
     AnalyzerInterface,
     AnalyzerOutput,
+    AnalyzerParam,
     InputColumn,
+    IntegerParam,
     OutputColumn,
 )
 
@@ -66,6 +68,45 @@ This is an example analyzer that counts the number of characters in each message
             ),
         ]
     ),
+    params=[
+        AnalyzerParam(
+            # This corresponds to the key in the parameter dictionary when accessed
+            # from the analyzer context.
+            id="fudge_factor",
+            # This is the human readable name that will be displayed in the user
+            # interface. It's optional and will fall back to the ID.
+            human_readable_name="Character Count Fudge Factor",
+            # Also optional, shown in the UI if provided.
+            description="""
+Adds to the character count, because data manipulation is
+good data science and ethically no-problemo.
+
+/s: In seriousness, please *don't* manipulate data.
+It's wrong. We are trying to fight misinformation :)
+            """,
+            # Follow the definition here to the module where all the supported
+            # param types are defined.
+            type=IntegerParam(
+                # Depending on the parameter type, you may be required to
+                # provide extra ranges/bounds for validation.
+                min=-1000,
+                max=1000,
+            ),
+            # Optional.
+            # Sets the default/initial value. This is one of the two ways to set
+            # a default parameter value, the other being using a default_params
+            # function (see the `__init__.py` file), which can suggest defaults
+            # in a data-dependent manner.
+            default=0,
+            # Optional.
+            # If you have an existing analyzer that previously hardcoded a parameter
+            # that you now want to customize, you can set this to the value it was
+            # hardcoded, and older analysis saves will use this value when the
+            # parameter is shown in the UI and accessed in the web presenter.
+            # Note: This is NOT a default value!
+            backfill_value=0,
+        )
+    ],
     outputs=[
         AnalyzerOutput(
             # This should be locally unique to the analyzer.

--- a/analyzers/example/example_base/main.py
+++ b/analyzers/example/example_base/main.py
@@ -20,6 +20,15 @@ def main(context: PrimaryAnalyzerContext):
     input_reader = context.input()
     df_input = input_reader.preprocess(pl.read_parquet(input_reader.parquet_path))
 
+    # The analysis parameters are provided in a dictionary. This is how you
+    # access them. The dictionary key must match the parameter ID in the interface.
+    fudge_factor_param = context.params.get("fudge_factor")
+
+    # You don't actually need to do this as the app will make sure all
+    # parameters are of the right type. But it's a good idea anyway.
+    # It also lets python narrow the type for you.
+    assert isinstance(fudge_factor_param, int), "Fudge factor must be an integer"
+
     # Now you can start your analysis. The following code is just a minimal example.
     #
     # The use of the ProgressReporter is optional. It helps breaking a
@@ -28,7 +37,10 @@ def main(context: PrimaryAnalyzerContext):
         df_count = df_input.select(
             pl.col("message_id"),
             # The input and output columns are as you define in the interface.
-            pl.col("message_text").str.len_chars().alias("character_count"),
+            pl.col("message_text")
+            .str.len_chars()
+            .add(fudge_factor_param)
+            .alias("character_count"),
         )
 
         # If you decide to process the data in small batches

--- a/analyzers/example/example_report/main.py
+++ b/analyzers/example/example_report/main.py
@@ -16,6 +16,9 @@ def main(context: SecondaryAnalyzerContext):
         .alias("is_long")
     )
 
+    # This will have been provided or backfilled by the app.
+    assert context.base_params.get("fudge_factor") is not None
+
     # Save the output to a parquet file. The output ID comes from the secondary
     # analyzer's interface.
     df_export.write_parquet(context.output("example_report").parquet_path)

--- a/analyzers/example/example_web/factory.py
+++ b/analyzers/example/example_web/factory.py
@@ -40,11 +40,14 @@ def factory(context: WebPresenterContext):
         }
     )
 
+    fudge_factor_param = context.base_params.get("fudge_factor")
     app.layout = Div(
         [
+            Div(f"Fudge factor: {fudge_factor_param}"),
+            Div("You naughty data scientist") if fudge_factor_param else None,
             Graph(
                 figure=fig,
                 style={"height": "100%", "flex-grow": "1"},
-            )
+            ),
         ]
     )

--- a/analyzers/example/test_data/output.csv
+++ b/analyzers/example/test_data/output.csv
@@ -1,4 +1,4 @@
 message_id,character_count
-msg_1,14
-msg_2,20
-msg_3,170
+msg_1,24
+msg_2,30
+msg_3,180

--- a/analyzers/example/test_data/output_report.csv
+++ b/analyzers/example/test_data/output_report.csv
@@ -1,4 +1,4 @@
 message_id,character_count,is_long
-msg_1,14,False
-msg_2,20,False
-msg_3,170,True
+msg_1,24,False
+msg_2,30,False
+msg_3,180,True

--- a/analyzers/example/test_example_base.py
+++ b/analyzers/example/test_example_base.py
@@ -37,6 +37,10 @@ def test_example_base():
                 separator=",",
             ),
         ),
+        # This is optional if your analyzer doesn't take parameters.
+        # You're responsible for making sure the analyzer you're testing
+        # get the parameters it needs.
+        params={"fudge_factor": 10},
         # These outputs are the expected outputs of the analyzer.
         # You don't need to specify all the outputs, only the ones you want to test.
         # The output IDs must match the IDs in the interface schema.

--- a/analyzers/example/test_example_report.py
+++ b/analyzers/example/test_example_report.py
@@ -15,6 +15,16 @@ def test_example_report():
     test_secondary_analyzer(
         interface,  # You provide the interface ...
         main,  # ... and the analyzer's entry point.
+        # This is optional if your secondar analyzer doesn't need reference
+        # to the primary analyzer parameters.
+        #
+        # You're responsible for making sure the analyzer you're testing
+        # get the parameters it needs.
+        #
+        # In this particular case, the value doesn't matter becuase it isn't used
+        # by the `example_report` secondary analyzer, but we have an `assert`
+        # statement for the parameter's existence just to make a point.
+        primary_params={"fudge_factor": 10},
         # A secondary analyzer requires the primary outputs to be provided.
         # All the outputs required by the secondary analyzer being tested
         # must be provided. But not all the primary outputs need to be provided

--- a/components/analysis_main.py
+++ b/components/analysis_main.py
@@ -1,8 +1,15 @@
 from colorama import Fore
 
 from app import AnalysisContext
-from terminal_tools import draw_box, open_directory_explorer, prompts, wait_for_key
+from terminal_tools import (
+    draw_box,
+    open_directory_explorer,
+    print_ascii_table,
+    prompts,
+    wait_for_key,
+)
 
+from .analysis_params import print_param_value
 from .context import ViewContext
 from .export_outputs import export_outputs
 
@@ -19,6 +26,22 @@ def analysis_main(
         with terminal.nest(
             draw_box(f"Analysis: {analysis.display_name}", padding_lines=0)
         ):
+            analyzer = analysis.analyzer_spec
+            param_rows = [
+                [
+                    param_spec.print_name,
+                    print_param_value(param_value),
+                ]
+                for param_spec in analyzer.params
+                if (param_value := analysis.backfilled_param_values.get(param_spec.id))
+                is not None
+            ]
+            if param_rows:
+                print_ascii_table(
+                    param_rows,
+                    header=["parameter name", "parameter value"],
+                )
+
             if is_draft:
                 print("⚠️  This analysis didn't complete successfully.  ⚠️")
 

--- a/components/analysis_params.py
+++ b/components/analysis_params.py
@@ -1,0 +1,197 @@
+from tempfile import TemporaryDirectory
+
+from pydantic import BaseModel
+
+from analyzer_interface import (
+    AnalyzerInterface,
+    AnalyzerParam,
+    IntegerParam,
+    ParamValue,
+    TimeBinningValue,
+)
+from app import ProjectContext
+from context import InputColumnProvider, PrimaryAnalyzerDefaultParametersContext
+from terminal_tools import print_ascii_table, prompts
+
+from .context import ViewContext
+
+
+def customize_analysis(
+    context: ViewContext,
+    project: ProjectContext,
+    analyzer: AnalyzerInterface,
+    column_mapping: dict[str, str],
+) -> dict[str, ParamValue] | None:
+    app = context.app
+    if not analyzer.params:
+        return dict()
+
+    with TemporaryDirectory() as temp_dir:
+        default_parameters_context = PrimaryAnalyzerDefaultParametersContext(
+            analyzer=analyzer,
+            store=app.context.storage,
+            temp_dir=temp_dir,
+            input_columns={
+                analyzer_column_name: InputColumnProvider(
+                    user_column_name=user_column_name,
+                    semantic=project.column_dict[user_column_name].semantic,
+                )
+                for analyzer_column_name, user_column_name in column_mapping.items()
+            },
+        )
+        analyzer_decl = app.context.suite.get_primary_analyzer(analyzer.id)
+        assert analyzer_decl, f"Analyzer `{analyzer.id}` not found"
+
+        param_values = {
+            **{
+                param_spec.id: static_param_default_value
+                for param_spec in analyzer_decl.params
+                if (static_param_default_value := param_spec.default) is not None
+            },
+            # Deliberately allow `None` to override here
+            **analyzer_decl.default_params(default_parameters_context),
+        }
+        param_values = {
+            param_id: param_value
+            for param_id, param_value in param_values.items()
+            if param_value is not None
+        }
+
+    while True:
+        with context.terminal.nest("Customization"):
+            param_states = [
+                ParamState(
+                    param_spec=param_spec,
+                    value=param_values.get(param_spec.id),
+                )
+                for param_spec in analyzer.params
+            ]
+
+            print_ascii_table(
+                [
+                    [
+                        param_state.param_spec.print_name,
+                        print_param_value(param_state.value),
+                    ]
+                    for param_state in param_states
+                ],
+                header=["parameter name", "parameter value"],
+            )
+
+            has_all_params = all(
+                (param_state.value is not None for param_state in param_states)
+            )
+
+            prompt_title = (
+                "Does this look right?"
+                if has_all_params
+                else "The analyzer needs more information before it can run."
+            )
+
+            prompt_choices = [
+                *([("Yes. Proceed.", (True, None))] if has_all_params else []),
+                *[
+                    (
+                        (
+                            f"Change {param_state.param_spec.print_name}"
+                            if param_state.value
+                            else f"Set {param_state.param_spec.print_name}"
+                        ),
+                        (False, param_state),
+                    )
+                    for param_state in param_states
+                ],
+            ]
+
+            prompt_answer: tuple[bool, ParamState | None] | None = prompts.list_input(
+                prompt_title, choices=prompt_choices
+            )
+            if not prompt_answer:
+                return None
+
+            proceed, param_to_edit = prompt_answer
+            if proceed:
+                return param_values
+
+            with context.terminal.nest(
+                f"Set {param_to_edit.param_spec.print_name}"
+            ) as scope:
+
+                def refresh():
+                    scope.refresh()
+                    description = param_to_edit.param_spec.description
+                    if description:
+                        print(f"\nHelp:\n\n{description}\n")
+
+                refresh()
+                param_value = edit_param(param_to_edit)
+                if param_value is not None:
+                    param_values[param_to_edit.param_spec.id] = param_value
+
+
+class ParamState(BaseModel):
+    param_spec: AnalyzerParam
+    value: ParamValue | None
+
+
+def print_param_value(value: ParamValue | None):
+    if isinstance(value, TimeBinningValue):
+        return value.to_human_readable_text()
+    if isinstance(value, int):
+        return str(value)
+    if value is None:
+        return "(not set)"
+    raise ValueError("Unsupported parameter type")
+
+
+def edit_param(state: ParamState) -> ParamValue | None:
+    param_type = state.param_spec.type
+    current_value = state.value
+    if param_type.type == "integer":
+        return edit_int_param(param_type, current_value)
+    if param_type.type == "time_binning":
+        return edit_time_binning_param(current_value)
+    raise ValueError("Unsupported parameter type")
+
+
+def edit_int_param(param_type: IntegerParam, current_value: int | None):
+    return prompts.int_input(
+        "Enter an integer value",
+        min=param_type.min,
+        max=param_type.max,
+        default=current_value,
+    )
+
+
+def edit_time_binning_param(
+    current_value: TimeBinningValue | None,
+) -> TimeBinningValue | None:
+    unit = prompts.list_input(
+        "Choose binning unit",
+        choices=[
+            ("Year", "year"),
+            ("Month", "month"),
+            ("Day", "day"),
+            ("Hour", "hour"),
+            ("Minute", "minute"),
+            ("Second", "second"),
+        ],
+        default=current_value.unit if current_value else None,
+    )
+    if not unit:
+        return None
+
+    amount = prompts.int_input(
+        "How many?",
+        min=1,
+        max=1000,
+        default=(
+            current_value.amount
+            if current_value and current_value.unit == unit
+            else None
+        ),
+    )
+    if not amount:
+        return None
+
+    return TimeBinningValue(unit=unit, amount=amount)

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -14,6 +14,7 @@ from tinydb import Query, TinyDB
 from xlsxwriter import Workbook
 
 from analyzer_interface.interface import AnalyzerOutput
+from analyzer_interface.params import ParamValue
 
 from .file_selector import FileSelectorStateManager
 
@@ -43,6 +44,7 @@ class AnalysisModel(BaseModel):
     path: str
     column_mapping: Optional[dict[str, str]] = None
     create_timestamp: Optional[float] = None
+    param_values: dict[str, ParamValue] = dict()
     is_draft: bool = False
 
     def create_time(self):
@@ -308,6 +310,7 @@ class Storage:
         display_name: str,
         primary_analyzer_id: str,
         column_mapping: dict[str, str],
+        param_values: dict[str, ParamValue],
     ) -> AnalysisModel:
         with self._lock_database():
             analysis_id = self._find_unique_analysis_id(project_id, display_name)
@@ -319,6 +322,7 @@ class Storage:
                 path=os.path.join("analysis", analysis_id),
                 column_mapping=column_mapping,
                 create_timestamp=datetime.now().timestamp(),
+                param_values=param_values,
                 is_draft=True,
             )
             self.db.insert(analysis.model_dump())

--- a/terminal_tools/prompts.py
+++ b/terminal_tools/prompts.py
@@ -139,7 +139,12 @@ def text(message: str, **kwargs):
 
 
 def int_input(
-    message: str, *, min: Optional[int] = None, max: Optional[int] = None, **kwargs
+    message: str,
+    *,
+    min: Optional[int] = None,
+    max: Optional[int] = None,
+    default: Optional[int] = None,
+    **kwargs,
 ) -> Optional[int]:
     """
     Wraps `inquirer`'s text input and catches KeyboardInterrupt
@@ -165,6 +170,7 @@ def int_input(
         lambda: inquirer_text(
             message,
             validate=lambda previous_answers, value: validate_value(value),
+            default=str(default) if default is not None else None,
             **kwargs,
         ),
         None,


### PR DESCRIPTION
This change introduces analyzer parameterization. Parameters can be defined using `AnalyzerParam` and queried via the analyzer/web presenter context objects. The CLI is updated to include a step where parameters are chosen, and they are reflected back when the analysis is viewed. The test helpers are also updated to include parameter provision.

The example analyzer, which performs simple character count, is updated to include a single parameter, namely `fudge_factor` that offsets the character count.

These parameter types are supported:
- `IntegerParam` (produces `int` value)
- `TimeBinningParam` (produces `TimeBinningValue`, essentially an object with attributes `unit` and `amount`.

The `TimeBinningParam` is currently unused, but it is defined in anticipation that it will be used by the hashtag tests. As such, a convenient method that produces a polars `truncate` expression is added to `TimeBinningValue` so it can just be dropped into the analyzer later.

![image](https://github.com/user-attachments/assets/bcd83c2d-b47a-4858-b94a-127f57644280)

![image](https://github.com/user-attachments/assets/ec0d55a3-eb3e-4523-968e-fc23684a480e)

![image](https://github.com/user-attachments/assets/c329f089-a7c4-4425-b829-5a2087449964)

![image](https://github.com/user-attachments/assets/bc986e07-bb0e-4590-871b-c0707be0b90a)

Closes #34

@KristijanArmeni 