### PR TITLE
Multi Tenancy Support

### DIFF
--- a/app/analysis_webserver_context.py
+++ b/app/analysis_webserver_context.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from dash import Dash
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from flask import Flask, render_template
 from pydantic import BaseModel
 from waitress import serve
@@ -63,6 +64,7 @@ class AnalysisWebServerContext(BaseModel):
                 analyzer_name=analyzer_name,
             )
 
+        app_dispatcher = DispatcherMiddleware(web_server)
         server_log = logging.getLogger("waitress")
         original_log_level = server_log.level
         original_disabled = server_log.disabled
@@ -70,9 +72,10 @@ class AnalysisWebServerContext(BaseModel):
         server_log.disabled = True
 
         try:
-            serve(web_server, host="127.0.0.1", port=8050)
-        finally:
             server_log.setLevel(original_log_level)
             server_log.disabled = original_disabled
+
+            serve(app_dispatcher, host="127.0.0.1", port=8050)
+        finally:
             for temp_dir in temp_dirs:
                 temp_dir.cleanup()

--- a/app/analysis_webserver_context.py
+++ b/app/analysis_webserver_context.py
@@ -4,10 +4,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from dash import Dash
-from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from flask import Flask, render_template
 from pydantic import BaseModel
 from waitress import serve
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from context import WebPresenterContext
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ plotly==5.24.1
 pandas==2.2.3 # needed by plotly
 pyarrow==17.0.0
 dash==2.18.1
-waitress==3.0.0
+waitress==3.0.2
 colorama==0.4.6
 fastexcel==0.13.0


### PR DESCRIPTION
I added the necessary middleware for both shiny and flask application instances to run on the same server (I.E Waitress). Also took the liberty to update Waitress in order to resolve two CVS reports generated by dependabot. Beyond those two things I'm just looking to confirm this change works for others before merging into `develop`

- https://github.com/civictechdc/mango-tango-cli/security/dependabot/2
- https://github.com/civictechdc/mango-tango-cli/security/dependabot/1