### PR TITLE
Add macOS code signing and build improvements

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -20,40 +20,33 @@ jobs:
             sha_command: pwsh -c "Get-FileHash -Algorithm SHA1 dist\mangotango_windows.exe | Format-Table Hash -HideTableHeaders > dist\mangotango_windows.exe.sha1"
             list_command: dir dist
             check_command: dist\mangotango_windows.exe --noop
-          - platform_name: MacOS 14
-            artifact_name: macos-14
-            os: macos-14
-            move_command: mv dist/mangotango dist/mangotango_macos_14
-            sha_command: shasum -a 1 dist/mangotango_macos_14 > dist/mangotango_macos_14.sha1
+          - platform_name: MacOS 13 (x86)
+            artifact_name: macos-x86
+            os: macos-13
+            move_command: mv dist/mangotango dist/mangotango_macos_x86
+            sha_command: shasum -a 1 dist/mangotango_macos_x86 > dist/mangotango_macos_x86.sha1
             list_command: ls -ll dist
-            check_command: dist/mangotango_macos_14 --noop
-          - platform_name: MacOS 15
-            artifact_name: macos-15
+            check_command: dist/mangotango_macos_x86 --noop
+          - platform_name: MacOS 15 (arm64)
+            artifact_name: macos-arm64
             os: macos-15
-            move_command: mv dist/mangotango dist/mangotango_macos_15
-            sha_command: shasum -a 1 dist/mangotango_macos_15 > dist/mangotango_macos_15.sha1
+            move_command: mv dist/mangotango dist/mangotango_macos_arm64
+            sha_command: shasum -a 1 dist/mangotango_macos_arm64 > dist/mangotango_macos_arm64.sha1
             list_command: ls -ll dist
-            check_command: dist/mangotango_macos_15 --noop
+            check_command: dist/mangotango_macos_arm64 --noop
 
     name: Build ${{ matrix.platform_name }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.12
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pip
-          key: ${{ matrix.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ matrix.os }}-pip-
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
 
       - name: Install dependencies
         run: |
@@ -61,8 +54,34 @@ jobs:
           pip install -r requirements.txt
 
       - name: Install PyInstaller
-        run: pip install pyinstaller
-
+        run: |
+          pip install pyinstaller
+          echo "PYINST_BIN=\"$(which pyinstaller)\"" >> "$GITHUB_ENV"
+      - name: Create macOS keychain
+        id: keychain
+        if: runner.os == 'macOS' && inputs.is_release
+        env:
+          APPLE_DEV_EMAIL: ${{secrets.APPLE_DEV_EMAIL}}
+          APP_SPEC_PASS: ${{secrets.APP_SPEC_PASS}}
+          APPLE_APP_CERTIFICATE: ${{secrets.DEV_APP_CERT}}
+          APPLE_APP_CERT_PASSWORD: ${{secrets.DEV_APP_CERT_PASS}}
+          APPLE_INST_CERTIFICATE: ${{secrets.DEV_INST_CERT}}
+          APPLE_INST_CERT_PASSWORD: ${{secrets.DEV_INST_CERT_PASS}}
+          APPLE_KEYCHAIN_PASS: ${{secrets.APPLE_KEY_PASS}}
+        run: |
+          echo "$APPLE_APP_CERTIFICATE" | base64 --decode > app_certificate.p12
+          echo "$APPLE_INST_CERTIFICATE" | base64 --decode > inst_certificate.p12
+          security create-keychain -p $APPLE_KEYCHAIN_PASS build.keychain
+          security default-keychain -s build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security unlock-keychain -p $APPLE_KEYCHAIN_PASS build.keychain
+          security import app_certificate.p12 -k build.keychain -P $APPLE_APP_CERT_PASSWORD -A
+          security import inst_certificate.p12 \
+          -k build.keychain \
+          -P "$APPLE_INST_CERT_PASSWORD" \
+          -A
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $APPLE_KEYCHAIN_PASS build.keychain
+          security find-identity -v -p codesigning -p macappstore
       - name: Print version string (for tag)
         id: get_version_tag
         if: ${{ github.ref_type == 'tag' }}
@@ -80,8 +99,9 @@ jobs:
         run: ${{ matrix.version_command }}
 
       - name: Build the executable
-        run: |
-          pyinstaller pyinstaller.spec
+        env:
+          APPLE_APP_CERT_ID: ${{secrets.APPLE_APP_CERT_ID}}
+        run: pyinstaller pyinstaller.spec
 
       - name: Rename the executable to include platform suffix
         run: ${{ matrix.move_command }}
@@ -89,12 +109,51 @@ jobs:
       - name: Compute the SHA1 hashsum
         run: ${{ matrix.sha_command }}
 
+      - name: Create and sign mac package
+        if: runner.os == 'macOS'
+        env:
+          APPLE_INST_CERT_ID: ${{secrets.APPLE_INST_CERT_ID}}
+          APPLE_KEYCHAIN_PASS: ${{secrets.APPLE_KEY_PASS}}
+        run: |
+          mkdir -p /tmp/mangotango/
+          ditto dist/mangotango_${{matrix.os}} /tmp/mangotango/mangotango
+          chmod +x /tmp/mangotango/mangotango
+          security unlock-keychain -p $APPLE_KEYCHAIN_PASS build.keychain
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_KEYCHAIN_PASS" build.keychain
+          security find-identity -v -p codesigning build.keychain
+          pkgbuild --identifier "org.mangotango.cli" --timestamp --root /tmp/mangotango --install-location /Applications "dist/mangotango_${{matrix.os}}_signed.pkg" --sign "$APPLE_INST_CERT_ID"
+          # productsign --timestamp --sign "$APPLE_INST_CERT_ID" dist/mangotango_${{matrix.os}}.pkg dist/mangotango_${{matrix.os}}_signed.pkg
+
+      - name: Notarize Mac package
+        if: runner.os == 'macOS' #&& inputs.is_release && ${{github.repository_id}} == 865611084
+        env:
+          APPLE_DEV_EMAIL: ${{secrets.APPLE_DEV_EMAIL}}
+          APPLE_TEAM_ID: ${{secrets.TEAM_ID}}
+          APP_SPEC_PASS: ${{secrets.APP_SPEC_PASS}}
+        run: xcrun notarytool submit dist/mangotango_${{matrix.os}}_signed.pkg --apple-id $APPLE_DEV_EMAIL --team-id $APPLE_TEAM_ID --password $APP_SPEC_PASS --wait > notarization_output.txt
+
+      - name: Staple the notarization ticket
+        if: runner.os == 'macOS'
+        run: xcrun stapler staple dist/mangotango_${{matrix.os}}_signed.pkg
+
+      - name: Clean up macOS Artifacts
+        if: runner.os == 'macOS'
+        run: |
+          rm -rf /tmp/mangotango
+          rm -rf dist/mangotango_${{matrix.os}}
+          rm -rf dist/mangotango_${{matrix.os}}.pkg
+          mv dist/mangotango_${{matrix.os}}_signed.pkg dist/mangotango_${{matrix.os}}.pkg
+
+      - name: Compute the SHA1 hashsum for macOS .pkg
+        if: runner.os == 'macOS'
+        run: ${{ matrix.sha_command }}
+
       - name: Inspect the dist/ directory before uploading artifacts
         run: ${{ matrix.list_command }}
 
       - name: Check that the executable runs
         if: inputs.is_release == false
-        run: ${{ matrix.check_command}}
+        run: ${{ matrix.check_command }}
 
       - name: Upload artifacts
         if: inputs.is_release

--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -6,7 +6,12 @@ on:
       is_release:
         required: true
         type: boolean
-
+  workflow_dispatch:
+    inputs:
+      is_release:
+        required: true
+        type: boolean
+        default: false
 jobs:
   build:
     strategy:

--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -2,16 +2,6 @@ name: Build Executables
 
 on:
   workflow_call:
-    inputs:
-      is_release:
-        required: true
-        type: boolean
-  workflow_dispatch:
-    inputs:
-      is_release:
-        required: true
-        type: boolean
-        default: false
 jobs:
   build:
     strategy:
@@ -25,20 +15,22 @@ jobs:
             sha_command: pwsh -c "Get-FileHash -Algorithm SHA1 dist\mangotango_windows.exe | Format-Table Hash -HideTableHeaders > dist\mangotango_windows.exe.sha1"
             list_command: dir dist
             check_command: dist\mangotango_windows.exe --noop
-          - platform_name: MacOS 13 (x86)
+          - platform_name: MacOS (x86)
             artifact_name: macos-x86
             os: macos-13
-            move_command: mv dist/mangotango dist/mangotango_macos_x86
-            sha_command: shasum -a 1 dist/mangotango_macos_x86 > dist/mangotango_macos_x86.sha1
+            move_command: mv dist/mangotango dist/mangotango_macos-x86
+            sha_command: shasum -a 1 dist/mangotango_macos-x86 > dist/mangotango_macos-x86.sha1
+            sha_command_pkg: shasum -a 1 dist/mangotango_macos-x86.pkg > dist/mangotango_macos-x86.pkg.sha1
             list_command: ls -ll dist
-            check_command: dist/mangotango_macos_x86 --noop
-          - platform_name: MacOS 15 (arm64)
+            check_command: dist/mangotango_macos-x86 --noop
+          - platform_name: MacOS (arm64)
             artifact_name: macos-arm64
             os: macos-15
-            move_command: mv dist/mangotango dist/mangotango_macos_arm64
-            sha_command: shasum -a 1 dist/mangotango_macos_arm64 > dist/mangotango_macos_arm64.sha1
+            move_command: mv dist/mangotango dist/mangotango_macos-arm64
+            sha_command: shasum -a 1 dist/mangotango_macos-arm64 > dist/mangotango_macos-arm64.sha1
+            sha_command_pkg: shasum -a 1 dist/mangotango_macos-arm64.pkg > dist/mangotango_macos-arm64.pkg.sha1
             list_command: ls -ll dist
-            check_command: dist/mangotango_macos_arm64 --noop
+            check_command: dist/mangotango_macos-arm64 --noop
 
     name: Build ${{ matrix.platform_name }}
     runs-on: ${{ matrix.os }}
@@ -64,7 +56,7 @@ jobs:
           echo "PYINST_BIN=\"$(which pyinstaller)\"" >> "$GITHUB_ENV"
       - name: Create macOS keychain
         id: keychain
-        if: runner.os == 'macOS' && inputs.is_release
+        if: runner.os == 'macOS'
         env:
           APPLE_DEV_EMAIL: ${{secrets.APPLE_DEV_EMAIL}}
           APP_SPEC_PASS: ${{secrets.APP_SPEC_PASS}}
@@ -121,47 +113,41 @@ jobs:
           APPLE_KEYCHAIN_PASS: ${{secrets.APPLE_KEY_PASS}}
         run: |
           mkdir -p /tmp/mangotango/
-          ditto dist/mangotango_${{matrix.os}} /tmp/mangotango/mangotango
+          ditto dist/mangotango_${{matrix.artifact_name}} /tmp/mangotango/mangotango
           chmod +x /tmp/mangotango/mangotango
           security unlock-keychain -p $APPLE_KEYCHAIN_PASS build.keychain
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_KEYCHAIN_PASS" build.keychain
           security find-identity -v -p codesigning build.keychain
-          pkgbuild --identifier "org.mangotango.cli" --timestamp --root /tmp/mangotango --install-location /Applications "dist/mangotango_${{matrix.os}}_signed.pkg" --sign "$APPLE_INST_CERT_ID"
-          # productsign --timestamp --sign "$APPLE_INST_CERT_ID" dist/mangotango_${{matrix.os}}.pkg dist/mangotango_${{matrix.os}}_signed.pkg
+          pkgbuild --identifier "org.mangotango.cli" --timestamp --root /tmp/mangotango --install-location /Applications "./dist/mangotango_${{matrix.artifact_name}}_signed.pkg" --sign "$APPLE_INST_CERT_ID"
 
       - name: Notarize Mac package
-        if: runner.os == 'macOS' #&& inputs.is_release && ${{github.repository_id}} == 865611084
+        if: runner.os == 'macOS'
         env:
           APPLE_DEV_EMAIL: ${{secrets.APPLE_DEV_EMAIL}}
           APPLE_TEAM_ID: ${{secrets.TEAM_ID}}
           APP_SPEC_PASS: ${{secrets.APP_SPEC_PASS}}
-        run: xcrun notarytool submit dist/mangotango_${{matrix.os}}_signed.pkg --apple-id $APPLE_DEV_EMAIL --team-id $APPLE_TEAM_ID --password $APP_SPEC_PASS --wait > notarization_output.txt
+        run: xcrun notarytool submit dist/mangotango_${{matrix.artifact_name}}_signed.pkg --apple-id $APPLE_DEV_EMAIL --team-id $APPLE_TEAM_ID --password $APP_SPEC_PASS --wait > notarization_output.txt
 
       - name: Staple the notarization ticket
         if: runner.os == 'macOS'
-        run: xcrun stapler staple dist/mangotango_${{matrix.os}}_signed.pkg
+        run: xcrun stapler staple dist/mangotango_${{matrix.artifact_name}}_signed.pkg
 
       - name: Clean up macOS Artifacts
         if: runner.os == 'macOS'
         run: |
           rm -rf /tmp/mangotango
-          rm -rf dist/mangotango_${{matrix.os}}
-          rm -rf dist/mangotango_${{matrix.os}}.pkg
-          mv dist/mangotango_${{matrix.os}}_signed.pkg dist/mangotango_${{matrix.os}}.pkg
+          rm -rf dist/mangotango_${{matrix.artifact_name}}
+          rm -rf dist/mangotango_${{matrix.artifact_name}}.pkg
+          mv dist/mangotango_${{matrix.artifact_name}}_signed.pkg dist/mangotango_${{matrix.artifact_name}}.pkg
 
       - name: Compute the SHA1 hashsum for macOS .pkg
         if: runner.os == 'macOS'
-        run: ${{ matrix.sha_command }}
+        run: ${{ matrix.sha_command_pkg }}
 
       - name: Inspect the dist/ directory before uploading artifacts
         run: ${{ matrix.list_command }}
 
-      - name: Check that the executable runs
-        if: inputs.is_release == false
-        run: ${{ matrix.check_command }}
-
       - name: Upload artifacts
-        if: inputs.is_release
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,12 @@ name: New Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+-?*"
+      - "v*.*.*"
   workflow_dispatch:
 
 jobs:
   call-build_exe:
     uses: ./.github/workflows/build_exe.yml
-    with:
-        is_release: true 
   release:
     needs: call-build_exe
     runs-on: ubuntu-latest
@@ -21,7 +19,8 @@ jobs:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
         with:
           files: |
             artifacts/**/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __private__
 /analysis_outputs
 VERSION
 *.DS_Store
+.env*

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,7 @@
 
 # Define the virtual environment and requirements file paths
 REPO_ROOT=$(pwd)
-VENV_PATH="$REPO_ROOT/venv"
+VENV_PATH="${VIRTUAL_ENV:=$REPO_ROOT/venv}"
 REQUIREMENTS_FILE="$REPO_ROOT/requirements-dev.txt"
 
 # Check if virtual environment exists

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -1,8 +1,11 @@
+# code: language=python
 # main.spec
 # This file tells PyInstaller how to bundle your application
-
 from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller.building.api import EXE,PYZ
+from PyInstaller.building.build_main import Analysis
 import sys
+import os
 
 block_cipher = None
 
@@ -35,6 +38,7 @@ a = Analysis(
 )
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
 if sys.platform == "darwin":
     exe = EXE(
         pyz,
@@ -46,7 +50,9 @@ if sys.platform == "darwin":
         debug=False,
         strip=True,
         upx=True,  # You can set this to False if you don’t want UPX compression
-        console=True  # Set to False if you don't want a console window
+        console=True,  # Set to False if you don't want a console window
+        entitlements_file="./mango.entitlements",
+        codesign_identity=os.getenv('APPLE_APP_CERT_ID'),
     )
 else:
     exe = EXE(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pyarrow-stubs==17.13
 black==24.10.0
 isort==5.13.2
 pytest==8.3.4
+pyinstaller==6.14.1


### PR DESCRIPTION
  ## Summary
  - Add comprehensive macOS code signing support with certificate-based signing
  - Implement notarization and stapling for macOS packages
  - Update build workflow to create signed .pkg installers for both x86 and arm64 architectures
  - Improve CI/CD pipeline with better caching and dependency management
  - Add PyInstaller to dev requirements and update pyinstaller.spec for code signing

  ## Changes
  - Enhanced `.github/workflows/build_exe.yml` with macOS keychain setup and code signing
  - Added notarization workflow for App Store compliance
  - Updated PyInstaller spec with entitlements and codesign identity
  - Improved virtual environment handling in bootstrap script
  - Added .env files to .gitignore for security
  - Streamlined release workflow by removing unused parameters

  ## Test plan
  - [x] Verify Windows builds continue to work
  - [x] Test macOS x86 and arm64 builds with code signing
  - [x] Confirm notarization process completes successfully
  - [x] Validate signed .pkg installers install correctly
  - [x] Check that executables run with proper permissions