### PR TITLE
Fix GitHub Actions workflow secret inheritance for build and release jobs

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -2,6 +2,18 @@ name: Build Executables
 
 on:
   workflow_call:
+    secrets:
+      APPLE_DEV_EMAIL:
+      APP_SPEC_PASS:
+      DEV_APP_CERT:
+      DEV_APP_CERT_PASS:
+      DEV_INST_CERT:
+      DEV_INST_CERT_PASS:
+      APPLE_KEY_PASS:
+      APPLE_APP_CERT_ID:
+      APPLE_INST_CERT_ID:
+      TEAM_ID:
+
     inputs:
       is_release:
         default: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   call-build_exe:
     uses: ./.github/workflows/build_exe.yml
+    secrets: inherit
   release:
     needs: call-build_exe
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,6 @@ jobs:
         run: pytest
   test_build:
       uses: ./.github/workflows/build_exe.yml
+      secrets: inherit
       with:
         is_release: false


### PR DESCRIPTION
## Summary
  - Fixes critical issue where secrets were not being properly passed to reusable workflows
  - Added `secrets: inherit` to both `test.yml` and `release.yml` workflows when calling `build_exe.yml`
  - Defined required secrets interface in `build_exe.yml` for Apple code signing and notarization

  ## Key Changes
  - **`.github/workflows/build_exe.yml`** - Added secrets interface definition for macOS code signing requirements
  - **`.github/workflows/test.yml`** - Added `secrets: inherit` to test_build job  
  - **`.github/workflows/release.yml`** - Added `secrets: inherit` to call-build_exe job

  This fix ensures that the macOS code signing and notarization process works correctly in both test and release contexts by properly inheriting secrets from the calling workflows.