### PR TITLE
[FEAT] Add N-gram analysis dashboard in Shiny

### DIFF
--- a/analyzers/ngrams/ngram_web/__init__.py
+++ b/analyzers/ngrams/ngram_web/__init__.py
@@ -1,8 +1,8 @@
-from analyzer_interface import WebPresenterDeclaration, WebPresenterInterface
+from analyzer_interface import WebPresenterDeclaration
 
 from .factory import factory
 from .interface import interface
 
 ngrams_web = WebPresenterDeclaration(
-    interface=interface, factory=factory, name=__name__, shiny=False
+    interface=interface, factory=factory, name=__name__, shiny=True
 )

--- a/analyzers/ngrams/ngram_web/app.py
+++ b/analyzers/ngrams/ngram_web/app.py
@@ -276,7 +276,8 @@ def server(input, output, sessions):
             return "Showing summary data. Select a data point by clicking on the scatter plot above to show n-gram specific data."
         else:
             total_reps = len(filtered)
-            return f"Ngram: {filtered['N-gram content'][0]}, Nr. total repetitions: {total_reps}"
+            ngram_string = filtered["N-gram content"][0]
+            return f"Ngram: {ngram_string}, Nr. total repetitions: {total_reps}"
 
     @render.data_frame
     def data_viewer():

--- a/analyzers/ngrams/ngram_web/app.py
+++ b/analyzers/ngrams/ngram_web/app.py
@@ -1,0 +1,289 @@
+import plotly.express as px
+import plotly.graph_objects as go
+import polars as pl
+from shiny import reactive, render, ui
+from shinywidgets import output_widget, render_widget
+
+from ..ngram_stats.interface import (
+    COL_NGRAM_DISTINCT_POSTER_COUNT,
+    COL_NGRAM_TOTAL_REPS,
+    COL_NGRAM_WORDS,
+)
+from ..ngrams_base.interface import (
+    COL_AUTHOR_ID,
+    COL_MESSAGE_TEXT,
+    COL_MESSAGE_TIMESTAMP,
+    COL_NGRAM_ID,
+    COL_NGRAM_LENGTH,
+)
+
+MANGO_DARK_GREEN = "#609949"
+CLICKED_COLOR = "red"
+data_stats = None  # secondary output
+data_full = None  # primary output
+ngram_choices_dict = {}
+
+
+def _set_global_state_vars(df_stats: pl.DataFrame, df_full: pl.DataFrame):
+    global data_stats, data_full
+
+    data_stats = df_stats
+    data_full = df_full
+
+
+def plot_scatter(data):
+    import numpy as np
+
+    # Add jitter to x-axis to separate overlapping points
+    # Since we're using log scale, we need to be careful with the jitter amount
+    np.random.seed(42)  # For reproducible jitter
+
+    # Create jitter as a small multiplier (5% of the log value)
+    jitter_factor = 0.05
+    data = data.with_columns(
+        (
+            pl.col("total_reps")
+            * (1 + np.random.uniform(-jitter_factor, jitter_factor, len(data)))
+        ).alias("total_reps_jittered")
+    )
+
+    n_gram_categories = data.select(pl.col("n").unique().sort()).to_series()
+
+    fig = px.scatter(
+        data_frame=data,
+        x="distinct_posters",
+        y="total_reps_jittered",
+        log_y=True,
+        log_x=True,
+        custom_data=["words", "ngram_id", "total_reps"],
+        color="n",
+        category_orders={"n": n_gram_categories},
+    )
+
+    fig.update_traces(
+        marker=dict(size=11, opacity=0.7, line=dict(width=0.5, color="white")),
+        hovertemplate="<br>".join(
+            [
+                "<b>Ngram:</b> %{customdata[0]}",
+                "<b>Frequency:</b> %{customdata[2]}",
+                "<b>Nr. unique posters:</b> %{x}",
+            ]
+        ),
+    )
+
+    # Customize the plot
+    fig.update_layout(
+        title_text="Repeated phrases and accounts",
+        yaxis_title="N-gram frequency",
+        xaxis_title="Nr. unique posters",
+        hovermode="closest",
+        legend=dict(title="N-gram length"),
+        template="plotly_white",
+    )
+
+    return fig
+
+
+# helper to clear markers from figure widget
+def _remove_markers(figure_widget: go.FigureWidget) -> go.FigureWidget:
+    traces_to_remove = []
+    for i, existing_trace in enumerate(figure_widget.data):
+        try:
+            if (
+                hasattr(existing_trace, "marker")
+                and hasattr(existing_trace.marker, "color")
+                and str(existing_trace.marker.color) == CLICKED_COLOR
+            ):
+                traces_to_remove.append(i)
+        except Exception:
+            continue
+
+    # Remove old markers in reverse order
+    for i in reversed(traces_to_remove):
+        try:
+            figure_widget.data = figure_widget.data[:i] + figure_widget.data[i + 1 :]
+        except Exception:
+            continue
+
+    return figure_widget
+
+
+def _get_app_layout(ngram_choices_dict: dict):
+    app_layout = [
+        ui.card(
+            ui.card_header("N-gram statistics"),
+            ui.input_selectize(
+                id="ngram_selector",
+                label="Included n-grams:",
+                choices=ngram_choices_dict,
+                selected=list(ngram_choices_dict.keys()),
+                multiple=True,
+            ),
+            output_widget("scatter_plot", height="400px"),
+        ),
+        ui.card(
+            ui.card_header("Data viewer"),
+            ui.output_text(id="data_info"),
+            ui.div(
+                ui.input_action_button(
+                    id="reset_button",
+                    label="Reset selection (show summary)",
+                    fill=False,
+                ),
+                style="display: inline-block; margin-bottom: 10px;",
+            ),
+            ui.output_data_frame("data_viewer"),
+        ),
+    ]
+
+    return app_layout
+
+
+def server(input, output, sessions):
+    @reactive.calc
+    def get_data():
+        global data_stats
+
+        return data_stats.filter(pl.col("n").is_in(input.ngram_selector()))
+
+    # Store the figure widget reference
+    current_figure_widget = reactive.value(None)
+
+    @reactive.effect
+    def handle_reset_button():
+        # if reset button is clicked
+        # disable it and clear traces
+        if input.reset_button():
+            # Reset the click data
+            click_data.set(None)
+            # Reset the scatter plot by removing any red markers
+            fig_widget = current_figure_widget()
+            if fig_widget is not None:
+                try:
+                    # Remove red marker traces
+                    fig_widget = _remove_markers(figure_widget=fig_widget)
+                except Exception:
+                    pass
+
+    @reactive.calc
+    def get_top_n_data():
+        global data_stats
+
+        data_top_n = data_stats.select(
+            [
+                COL_NGRAM_WORDS,
+                COL_NGRAM_TOTAL_REPS,
+                COL_NGRAM_DISTINCT_POSTER_COUNT,
+                COL_NGRAM_LENGTH,
+            ]
+        ).rename(
+            {
+                COL_NGRAM_WORDS: "N-gram content",
+                COL_NGRAM_TOTAL_REPS: "Nr. total repetitions",
+                COL_NGRAM_DISTINCT_POSTER_COUNT: "Nr. unique posters",
+                COL_NGRAM_LENGTH: "N-gram length",
+            }
+        )
+
+        return data_top_n
+
+    click_data = reactive.value(None)
+
+    @reactive.calc
+    def get_filtered_data():
+        clicked = click_data()
+
+        SEL_COLUMNS = [
+            COL_AUTHOR_ID,
+            COL_NGRAM_WORDS,
+            COL_MESSAGE_TEXT,
+            COL_MESSAGE_TIMESTAMP,
+        ]
+        COL_RENAME = ["Unique user ID", "N-gram content", "Post content", "Timestamp"]
+
+        old2new = {k: v for k, v in zip(SEL_COLUMNS, COL_RENAME)}
+
+        if clicked and isinstance(clicked, dict) and COL_NGRAM_ID in clicked:
+            ngram_id = clicked[COL_NGRAM_ID]
+            filtered = data_full.filter(pl.col(COL_NGRAM_ID) == ngram_id)
+
+            filtered = filtered.with_columns(
+                pl.col(COL_MESSAGE_TIMESTAMP).dt.strftime("%B %d, %Y %I:%M %p")
+            )
+            filtered = filtered.select(SEL_COLUMNS).rename(old2new)
+            return filtered
+        else:
+            # Return empty dataframe with the right columns when nothing is clicked
+            return data_full.select(SEL_COLUMNS).head(0)
+
+    def on_point_click(trace, points, state):
+        if not hasattr(points, "point_inds") or not points.point_inds:
+            return
+
+        # Extract ngram_id from customdata
+        point_idx = points.point_inds[0]
+
+        try:
+            # Access customdata from the trace
+            customdata = trace.customdata
+            if customdata is not None and len(customdata) > point_idx:
+                ngram_id = customdata[point_idx][
+                    1
+                ]  # ngram_id is second item in customdata
+                click_data.set({COL_NGRAM_ID: ngram_id, "points": points})
+            else:
+                click_data.set(points)
+        except Exception:
+            click_data.set(points)
+
+        fig_widget = trace.parent
+
+        # Clear markers from previous clicks
+        fig_widget = _remove_markers(figure_widget=fig_widget)
+
+        # Add new green marker at clicked point
+        fig_widget.add_scatter(
+            x=[points.xs[0]],
+            y=[points.ys[0]],
+            mode="markers",
+            marker=dict(size=15, color=CLICKED_COLOR),
+            hoverinfo="skip",
+            showlegend=False,
+        )
+
+    @render_widget
+    def scatter_plot():
+        df = get_data()
+        fig = plot_scatter(data=df)
+
+        # Create FigureWidget directly from the figure
+        fig_widget = go.FigureWidget(fig)
+
+        # Store reference to figure widget for reset functionality
+        current_figure_widget.set(fig_widget)
+
+        # Attach click handler to all traces (one for each color group)
+        for trace in fig_widget.data:
+            trace.on_click(on_point_click)
+
+        return fig_widget
+
+    @render.text
+    def data_info():
+        filtered = get_filtered_data()
+
+        if filtered.is_empty():
+            return "Showing summary data. Select a data point by clicking on the scatter plot above to show n-gram specific data."
+        else:
+            total_reps = len(filtered)
+            return f"Ngram: {filtered['N-gram content'][0]}, Nr. total repetitions: {total_reps}"
+
+    @render.data_frame
+    def data_viewer():
+        data_for_display = get_filtered_data()
+
+        # Show summary data if no point is selected (filtered data is empty)
+        if data_for_display.is_empty():
+            data_for_display = get_top_n_data()
+
+        return render.DataGrid(data_for_display, width="100%")

--- a/analyzers/ngrams/ngram_web/factory.py
+++ b/analyzers/ngrams/ngram_web/factory.py
@@ -1,167 +1,63 @@
-import re
-from itertools import accumulate
-from typing import Optional
-
-import plotly.express as px
-import plotly.graph_objects as go
 import polars as pl
-from dash import Input as DashInput
-from dash import Output
-from dash.dcc import Graph
-from dash.dcc import Input as DccInput
-from dash.dcc import RadioItems
-from dash.html import H2, Datalist, Div, Em, Label, Option, P
+from dash import html
+from shiny.ui import nav_panel
 
-from analyzer_interface.context import WebPresenterContext
-
-from ..ngram_stats.interface import (
-    COL_NGRAM_DISTINCT_POSTER_COUNT,
-    COL_NGRAM_TOTAL_REPS,
-    COL_NGRAM_WORDS,
-    OUTPUT_NGRAM_STATS,
+from analyzer_interface.context import (
+    FactoryOutputContext,
+    ShinyContext,
+    WebPresenterContext,
 )
+from app.shiny import page_dependencies
+
+from ..ngram_stats.interface import OUTPUT_NGRAM_FULL, OUTPUT_NGRAM_STATS
 from ..ngram_stats.interface import interface as ngram_stats
+from .app import _get_app_layout, _set_global_state_vars, server
+
+data_stats = None
+data_full = None
 
 
-def factory(context: WebPresenterContext):
-    df = pl.read_parquet(
-        context.dependency(ngram_stats).table(OUTPUT_NGRAM_STATS).parquet_path
+def factory(web_context: WebPresenterContext):
+    # get secondary output data (for plot)
+    df_stats = pl.read_parquet(
+        web_context.dependency(ngram_stats).table(OUTPUT_NGRAM_STATS).parquet_path
     )
-    all_grams = sorted(set(df[COL_NGRAM_WORDS].str.split(" ").explode()))
-    explanation_total = "N-grams to the right are repeated by more users. N-grams higher up are repeated more times overall."
-    explanation_amplification = "N-grams to the right are repeated by more users. N-grams higher up are repeated more times on average per user."
 
-    @context.dash_app.callback(
-        [Output("scatter-plot", "figure"), Output("explanation", "children")],
-        [DashInput("grams-list-input", "value"), DashInput("y-axis", "value")],
+    # get the full report data (for Data viewer)
+    df_full = pl.read_parquet(
+        web_context.dependency(ngram_stats).table(OUTPUT_NGRAM_FULL).parquet_path
     )
-    def update_figure(filter_text: Optional[str], y_axis: str):
-        y_label = (
-            "Total Repetition"
-            if y_axis == "total_repetition"
-            else "Amplification Factor"
-        )
-        y_legend_label = (
-            "Avg Repetitions Per User"
-            if y_axis == "amplification_factor"
-            else "Total Repetition (All Users)"
-        )
-        explanation = (
-            explanation_total
-            if y_axis == "total_repetition"
-            else explanation_amplification
-        )
 
-        matcher = create_word_matcher(filter_text or "", pl.col(COL_NGRAM_WORDS))
-        plotted_df = df.filter(matcher) if matcher is not None else df
-        if plotted_df.height == 0:
-            fig = go.Figure()
-            fig.update_layout(
-                xaxis_title="User Count",
-                yaxis_title=y_label,
-                annotations=[
-                    {
-                        "text": "No matching n-grams found",
-                        "x": 0.5,
-                        "y": 0.5,
-                        "xref": "paper",
-                        "yref": "paper",
-                        "showarrow": False,
-                    }
-                ],
-            )
-            return fig, explanation
+    # find the different ngram categories in the data
+    ngram_choices = df_stats.select(pl.col("n").unique().sort()).to_series().to_list()
 
-        x_value = plotted_df[COL_NGRAM_DISTINCT_POSTER_COUNT]
-        y_value = (
-            plotted_df[COL_NGRAM_TOTAL_REPS]
-            if y_axis == "total_repetition"
-            else plotted_df[COL_NGRAM_TOTAL_REPS]
-            / plotted_df[COL_NGRAM_DISTINCT_POSTER_COUNT]
-        )
+    ngram_choices_dict = {i: f"{i}-grams" for i in ngram_choices}
 
-        fig = px.scatter(
-            x=x_value,
-            y=y_value,
-            labels={"x": "User Count", "y": y_label},
-            log_y=True,
-            log_x=True,
-        )
+    # make sure this column is categorical (to work for plotly)
+    df_stats = df_stats.with_columns(pl.col("n").cast(pl.String))
 
-        fig.update_traces(
-            hovertemplate='<b>"%{customdata}"</b><br>'
-            + "User Count: %{x}<br>"
-            + y_legend_label
-            + ": %{y}<br>"
-            + "<extra></extra>",
-            customdata=plotted_df[COL_NGRAM_WORDS],
-        )
+    # make sure the app has access to these varables
+    _set_global_state_vars(df_stats=df_stats, df_full=df_full)
 
-        return fig, explanation
+    app_layout = _get_app_layout(ngram_choices_dict=ngram_choices_dict)
 
-    fig = update_figure(None, "total_repetition")
-
-    context.dash_app.layout = Div(
-        style={"display": "flex", "flex-direction": "column", "height": "100%"},
-        children=[
-            Div(
-                [
-                    H2("N-gram repetition statistics"),
-                    P(
-                        [
-                            "Show on Y-axis: ",
-                            RadioItems(
-                                id="y-axis",
-                                options=[
-                                    {
-                                        "label": "Total Repetition",
-                                        "value": "total_repetition",
-                                    },
-                                    {
-                                        "label": "Amplification Factor",
-                                        "value": "amplification_factor",
-                                    },
-                                ],
-                                value="total_repetition",
-                                inline=True,
-                                style={"display": "inline-block"},
-                            ),
-                        ]
-                    ),
-                    P(Em(id="explanation", children=explanation_total)),
-                    P(
-                        [
-                            Label(
-                                "Search for n-grams containing: ",
-                                htmlFor="grams-list-input",
-                            ),
-                            Datalist(
-                                id="grams-list",
-                                children=[Option(value=gram) for gram in all_grams],
-                            ),
-                            DccInput(
-                                id="grams-list-input", type="text", list="grams-list"
-                            ),
-                        ]
-                    ),
-                ]
+    web_context.dash_app.layout = html.Div(
+        [
+            html.H1("Hashtag Analysis Dashboard"),
+            html.Iframe(
+                src="http://localhost:8050/shiny",  # Shiny app will run on port 8051
+                style={"width": "100%", "height": "800px", "border": "none"},
             ),
-            Graph(
-                id="scatter-plot",
-                figure=fig,
-                style={"height": "300px", "flex-grow": "1"},
-            ),
-        ],
+        ]
     )
 
-
-def create_word_matcher(subject: str, col: pl.Expr) -> Optional[pl.Expr]:
-    subject = subject.strip().lower()
-    words = re.split(r"[^\w]", subject)
-    words = [word for word in words if word]
-    if not words:
-        return None
-    return accumulate(
-        (col.str.contains("(^|[^\\w])" + re.escape(word)) for word in words),
-        lambda a, b: a & b,
+    return FactoryOutputContext(
+        shiny=ShinyContext(
+            server_handler=server,
+            panel=nav_panel(
+                "Dashboard",
+                page_dependencies,
+                app_layout,
+            ),
+        )
     )


### PR DESCRIPTION
Addresses #147 and adds the first version of N-gram dashboard in Shiny.

The dashboard has two components: 
1. An interactive scatter plot in Plotly (n-gram frequency vs. nr. unique posters)
2. A Data viewer panel which shows the n-gram data (if a data point is clicked) or a summary data (top 100 N-grams) if nothing is clicked (or if a user resets selection).

### Main changes

- adds `analyzers/ngrams/ngram_web/app.py` --> main app logic with plotting
- update `factory.py` accordingly

### Demo preview

https://github.com/user-attachments/assets/6ed3c650-abf0-476e-aa05-26cb52c59575


