### PR TITLE
[FIX, FEAT] Add support for native datetime formats, strip timezone information when importing string-based date columns

### DIFF
--- a/preprocessing/series_semantic.py
+++ b/preprocessing/series_semantic.py
@@ -34,13 +34,53 @@ class SeriesSemantic(BaseModel):
         return self.column_type(series.dtype)
 
 
-datetime_string = SeriesSemantic(
-    semantic_name="datetime",
-    column_type=pl.String,
-    try_convert=lambda s: s.str.strptime(pl.Datetime, strict=False),
+def parse_datetime_with_tz(s: pl.Series) -> pl.Series:
+    """Remove timezone substring (e.g. UTC) in pl.Series and conver it to datetime"""
+    # find a timezone code
+    tz_code_regex = r" ([A-Z]{3,4})$"  # UTC, ET, ...
+
+    return s.str.replace(tz_code_regex, "").str.strptime(pl.Datetime(), strict=False)
+
+
+native_date = SeriesSemantic(
+    semantic_name="native_date",
+    column_type=pl.Date,  # Matches native Date columns
+    try_convert=lambda s: s,  # No conversion needed
+    validate_result=lambda s: constant_series(s, True),  # Always valid
     data_type="datetime",
 )
 
+native_datetime = SeriesSemantic(
+    semantic_name="native_datetime",
+    column_type=pl.Datetime,  # Matches native DateTime columns
+    try_convert=lambda s: s,  # No conversion needed
+    validate_result=lambda s: constant_series(s, True),  # Always valid
+    data_type="datetime",
+)
+
+datetime_string = SeriesSemantic(
+    semantic_name="datetime",
+    column_type=pl.String,
+    try_convert=parse_datetime_with_tz,
+    validate_result=lambda s: s.is_not_null(),
+    data_type="datetime",
+)
+
+date_string = SeriesSemantic(
+    semantic_name="date",
+    column_type=pl.String,
+    try_convert=lambda s: s.str.strptime(pl.Date, strict=False),  # Convert to pl.Date
+    validate_result=lambda s: s.is_not_null(),
+    data_type="datetime",  # Still maps to datetime for analyzer compatibility
+)
+
+time_string = SeriesSemantic(
+    semantic_name="time",
+    column_type=pl.String,
+    try_convert=lambda s: s.str.strptime(pl.Time, strict=False),  # Convert to pl.Time
+    validate_result=lambda s: s.is_not_null(),
+    data_type="time",
+)
 
 timestamp_seconds = SeriesSemantic(
     semantic_name="timestamp_seconds",
@@ -107,7 +147,11 @@ boolean_catch_all = SeriesSemantic(
 )
 
 all_semantics = [
+    native_datetime,
+    native_date,
     datetime_string,
+    date_string,
+    time_string,
     timestamp_seconds,
     timestamp_milliseconds,
     url,

--- a/preprocessing/test_series_semantic.py
+++ b/preprocessing/test_series_semantic.py
@@ -1,0 +1,150 @@
+from datetime import datetime
+
+import polars as pl
+
+from preprocessing.series_semantic import (
+    date_string,
+    datetime_string,
+    infer_series_semantic,
+    native_date,
+    native_datetime,
+    parse_datetime_with_tz,
+    text_catch_all,
+    time_string,
+)
+
+
+# Individual Semantic Pattern Tests
+def test_native_date_recognition():
+    """Test that pl.Date columns get recognized correctly"""
+    series = pl.Series(
+        [datetime(2025, 1, 1).date(), datetime(2025, 1, 2).date()], dtype=pl.Date
+    )
+    assert native_date.check(series)
+
+
+def test_native_datetime_recognition():
+    """Test that pl.Datetime columns get recognized correctly"""
+    series = pl.Series([datetime(2025, 1, 1, 12, 0), datetime(2025, 1, 2, 13, 0)])
+    assert native_datetime.check(series)
+
+
+def test_datetime_with_timezone_parsing():
+    """Test parsing datetime strings with timezone"""
+    series = pl.Series(["2025-02-28 00:36:15 UTC", "2025-02-28 00:36:13 UTC"])
+    assert datetime_string.check(series)
+
+    # Test conversion
+    result = datetime_string.try_convert(series)
+    assert result.dtype == pl.Datetime
+    assert result.is_not_null().all()
+
+
+def test_date_string_parsing():
+    """Test date-only string parsing"""
+    series = pl.Series(["2025-02-28", "2025-02-27"])
+    assert date_string.check(series)
+
+    result = date_string.try_convert(series)
+    assert result.dtype == pl.Date
+    assert result.is_not_null().all()
+
+
+def test_time_string_parsing():
+    """Test time-only string parsing"""
+    series = pl.Series(["14:30:15", "09:15:30"])
+    assert time_string.check(series)
+
+    result = time_string.try_convert(series)
+    assert result.dtype == pl.Time
+    assert result.is_not_null().all()
+
+
+def test_text_catch_all():
+    """Test free form text parsing"""
+    series = pl.Series(
+        ["First post with some content!", "a different no all caps post", "THIRD POST"]
+    )
+    assert text_catch_all.check(series)
+
+    result = text_catch_all.try_convert(series)
+    assert result.dtype == pl.String
+
+    semantic = infer_series_semantic(series)
+    assert semantic.semantic_name == "free_text"
+    assert semantic.data_type == "text"
+
+
+def test_datetime_timezone_inference():
+    """Test main inference function with timezone datetime"""
+    series = pl.Series(["2025-02-28 00:36:15 UTC"] * 10)
+    semantic = infer_series_semantic(series)
+
+    assert semantic is not None
+    assert semantic.semantic_name == "datetime"
+    assert semantic.data_type == "datetime"
+
+
+def test_native_types_inference():
+    """Test that native temporal types get recognized"""
+    date_series = pl.Series([datetime(2025, 1, 1).date()] * 10, dtype=pl.Date)
+    datetime_series = pl.Series([datetime(2025, 1, 1, 12, 0)] * 10)
+
+    assert infer_series_semantic(date_series).semantic_name == "native_date"
+    assert infer_series_semantic(datetime_series).semantic_name == "native_datetime"
+
+
+def test_threshold_behavior():
+    """Test that recognition threshold works correctly"""
+
+    # 70% of data is date, the rest is text
+    mixed_series = pl.Series(["2025-01-01 UTC"] * 7 + ["not_a_date"] * 3)
+
+    # Should work with the right threshold (i.e. > 50%)
+    semantic_low = infer_series_semantic(mixed_series, threshold=0.5)
+    assert semantic_low.semantic_name == "datetime"
+
+    # Check a threshold that's not met, should defer to free_text
+    semantic_high = infer_series_semantic(mixed_series, threshold=0.8)
+    assert semantic_high.semantic_name == "free_text"
+
+
+# Phase 3: Helper Function Tests
+def test_parse_datetime_with_tz():
+    """Test timezone parsing helper function"""
+
+    # heterogenous timezone, unrealistic scenario otherwise
+    series = pl.Series(["2025-02-28 00:36:15 UTC", "2025-02-28 00:36:13 EST"])
+    result = parse_datetime_with_tz(series)
+
+    assert isinstance(result, pl.Series)
+    assert result.dtype == pl.Datetime
+    assert result.is_not_null().all()
+
+
+def test_parse_datetime_with_tz_no_timezone():
+    """Test datetime parsing without timezone suffix"""
+    series = pl.Series(["2025-02-28 00:36:15", "2025-02-28 00:36:13"])
+    result = parse_datetime_with_tz(series)
+
+    assert result.dtype == pl.Datetime
+    assert result.is_not_null().all()
+
+
+# Edge cases
+def test_all_none_series():
+    """Test series with all null values"""
+    null_series = pl.Series([None, None, None], dtype=pl.String)
+    semantic = infer_series_semantic(null_series)
+    assert semantic.semantic_name == "free_text"
+
+
+def test_mixed_valid_invalid_dates():
+    """Test series with mix of valid and invalid datetime strings"""
+    mixed_series = pl.Series(["2025-01-01 UTC", "invalid_date", "2025-01-02 UTC"])
+    semantic = infer_series_semantic(mixed_series)
+    # should be free_text with threshold 0.8
+    assert semantic.semantic_name == "free_text"
+
+    semantic = infer_series_semantic(series=mixed_series, threshold=0.2)
+    assert semantic.semantic_name == "datetime"

--- a/preprocessing/test_series_semantic.py
+++ b/preprocessing/test_series_semantic.py
@@ -113,8 +113,8 @@ def test_threshold_behavior():
 def test_parse_datetime_with_tz():
     """Test timezone parsing helper function"""
 
-    # heterogenous timezone, unrealistic scenario otherwise
-    series = pl.Series(["2025-02-28 00:36:15 UTC", "2025-02-28 00:36:13 EST"])
+    # Use same timezone to avoid warning
+    series = pl.Series(["2025-02-28 00:36:15 UTC", "2025-02-28 00:36:13 UTC"])
     result = parse_datetime_with_tz(series)
 
     assert isinstance(result, pl.Series)


### PR DESCRIPTION


### Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

<!-- Please check the type of change your PR introduces: -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
So far, the `preprocessing/series_semantic.py` module was handling string-based "datetime" columns by trying to convert them to `datetime` or else leaving them as `free_text`. Relatedly, `series_semantic` had no support for data that was already stored as `datetime` on disk -- those were silently dropped, leading to users not being able to select them.

Issue Number: #180 (also #191, #193)

### What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

We add/update the following `SeriesSemantic` converters:
- `native_date` and `native_datetime` to represent cases when datatime columns are already stored as datetime on disk. This should prevent such columns from being dropped.
- `datetime_string` is made to drop timezone strings (e.g. UTC) to prevent conversion to `pl.Datetime` via `series.str.strptime` from failing

### Example (Ukraine-Russia dataset)

For example, this is how the date(time) column types are detected now (previously `date` and `time` were silently dropped and `created_at` was imported as `free_text`):

<img width="349" height="284" alt="Screenshot 2025-08-21 at 3 56 32 PM" src="https://github.com/user-attachments/assets/09c76699-5347-4ed4-8dbf-214e9d06e8da" />


### Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
