### PR TITLE
Use Rich for printing tables, prompts and panels in welcome scree (replaces: PR #185)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 24.10.0
     hooks:
       - id: black

--- a/components/analysis_params.py
+++ b/components/analysis_params.py
@@ -1,5 +1,6 @@
 from tempfile import TemporaryDirectory
 
+import polars as pl
 from pydantic import BaseModel
 
 from analyzer_interface import (
@@ -11,7 +12,7 @@ from analyzer_interface import (
 )
 from app import ProjectContext
 from context import InputColumnProvider, PrimaryAnalyzerDefaultParametersContext
-from terminal_tools import print_ascii_table, prompts
+from terminal_tools import prompts, smart_print_data_frame
 
 from .context import ViewContext
 
@@ -58,7 +59,7 @@ def customize_analysis(
         }
 
     while True:
-        with context.terminal.nest("Customization"):
+        with context.terminal.nest("◆◆ Parameter customization ◆◆"):
             param_states = [
                 ParamState(
                     param_spec=param_spec,
@@ -67,15 +68,21 @@ def customize_analysis(
                 for param_spec in analyzer.params
             ]
 
-            print_ascii_table(
-                [
-                    [
-                        param_state.param_spec.print_name,
-                        print_param_value(param_state.value),
-                    ]
-                    for param_state in param_states
-                ],
-                header=["parameter name", "parameter value"],
+            smart_print_data_frame(
+                data_frame=pl.DataFrame(
+                    {
+                        "parameter name": [
+                            param_state.param_spec.print_name
+                            for param_state in param_states
+                        ],
+                        "parameter value": [
+                            print_param_value(param_state.value)
+                            for param_state in param_states
+                        ],
+                    }
+                ),
+                title="Analysis Parameters",
+                apply_color=None,
             )
 
             has_all_params = all(

--- a/components/new_analysis.py
+++ b/components/new_analysis.py
@@ -217,10 +217,9 @@ def new_analysis(
                 )
 
                 if selected_user_column is not None:
-                    draft_column_mapping[
-                        selected_analyzer_column.name
-                    ] = selected_user_column.name
-
+                    draft_column_mapping[selected_analyzer_column.name] = (
+                        selected_user_column.name
+                    )
         param_values = customize_analysis(
             context, project, analyzer, final_column_mapping
         )

--- a/components/new_analysis.py
+++ b/components/new_analysis.py
@@ -16,9 +16,9 @@ from app import ProjectContext
 from context import InputColumnProvider, PrimaryAnalyzerDefaultParametersContext
 from terminal_tools import (
     draw_box,
-    print_data_frame,
     print_dialog_section_title,
     prompts,
+    smart_print_data_frame,
     wait_for_key,
 )
 
@@ -64,7 +64,7 @@ def new_analysis(
                 )
                 required_cols_dict["Description"].append(input_column.description)
 
-            print_data_frame(
+            smart_print_data_frame(
                 data_frame=pl.DataFrame(required_cols_dict),
                 title=None,
                 apply_color="row-wise",
@@ -125,8 +125,11 @@ def new_analysis(
                     }
                 )
 
-                print_data_frame(
-                    data_frame=mapping_df, title=None, apply_color="row-wise"
+                smart_print_data_frame(
+                    data_frame=mapping_df,
+                    title=None,
+                    apply_color="row-wise",
+                    smart_print=False,
                 )
 
                 sample_input_df = pl.DataFrame(
@@ -140,10 +143,11 @@ def new_analysis(
                     }
                 )
                 print("Your test data would look like this:")
-                print_data_frame(
+                smart_print_data_frame(
                     data_frame=sample_input_df,
                     title="Sample input data",
                     apply_color="column-wise",
+                    smart_print=False,
                 )
 
                 mapping_ok = prompts.confirm(

--- a/components/new_analysis.py
+++ b/components/new_analysis.py
@@ -1,4 +1,3 @@
-from tempfile import TemporaryDirectory
 from traceback import format_exc
 from typing import Optional
 
@@ -7,20 +6,12 @@ import polars as pl
 from analyzer_interface import (
     AnalyzerInterface,
     InputColumn,
-    ParamValue,
     UserInputColumn,
     column_automap,
     get_data_type_compatibility_score,
 )
 from app import ProjectContext
-from context import InputColumnProvider, PrimaryAnalyzerDefaultParametersContext
-from terminal_tools import (
-    draw_box,
-    print_dialog_section_title,
-    prompts,
-    smart_print_data_frame,
-    wait_for_key,
-)
+from terminal_tools import draw_box, prompts, smart_print_data_frame, wait_for_key
 
 from .analysis_params import customize_analysis
 from .context import ViewContext
@@ -53,7 +44,7 @@ def new_analysis(
             print("")
             print(analyzer.long_description or analyzer.short_description)
             print("")
-            print_dialog_section_title("◆◆ Required Input ◆◆")
+            print("◆◆ Required Input ◆◆")
             print("The test requires these columns in the input data:")
             print("")
 

--- a/components/select_project.py
+++ b/components/select_project.py
@@ -34,9 +34,8 @@ def select_project(ctx: ViewContext):
                 data_frame=df.head(5),
                 title="Input data preview",
                 apply_color=None,
+                caption=f"Total rows: {project.data_row_count:,}",
             )
-
-            print(f"(Total {project.data_row_count} rows)")
 
             confirm_load = prompts.confirm("Load this project?", default=True)
             if confirm_load:

--- a/components/select_project.py
+++ b/components/select_project.py
@@ -1,15 +1,7 @@
 from typing import Optional
 
-import polars as pl
-
 from app import ProjectContext
-from terminal_tools import (
-    draw_box,
-    print_ascii_table,
-    prompts,
-    smart_print_data_frame,
-    wait_for_key,
-)
+from terminal_tools import draw_box, prompts, smart_print_data_frame, wait_for_key
 
 from .context import ViewContext
 
@@ -38,41 +30,14 @@ def select_project(ctx: ViewContext):
             draw_box(f"Project: {project.display_name}", padding_lines=0)
         ):
             df = project.preview_data
-            # print_ascii_table(
-            #    [
-            #        [preview_value(cell) for cell in row]
-            #        for row in df.head(10).iter_rows()
-            #    ],
-            #    header=df.columns,
-            # )
-
             smart_print_data_frame(
                 data_frame=df.head(5),
                 title="Input data preview",
-                apply_color="column_data_type",
-            )
-            # print(df.head(5))
-
-            print(f"(Total {project.data_row_count} rows)")
-            # print("Inferred column semantics:")
-            # print_ascii_table(
-            #    rows=[
-            #        [col.name, col.semantic.semantic_name] for col in project.columns
-            #    ],
-            #    header=["Column", "Semantic"],
-            # )
-            smart_print_data_frame(
-                data_frame=pl.DataFrame(
-                    {
-                        "Column": [col.name for col in project.columns],
-                        "Data Type": [
-                            col.semantic.semantic_name for col in project.columns
-                        ],
-                    }
-                ),
-                title="Inferred data types",
                 apply_color=None,
             )
+
+            print(f"(Total {project.data_row_count} rows)")
+
             confirm_load = prompts.confirm("Load this project?", default=True)
             if confirm_load:
                 return project

--- a/components/splash.py
+++ b/components/splash.py
@@ -1,8 +1,3 @@
-"""
-Logo generated with: https://github.com/shinshin86/oh-my-logo
-(used as: `npx oh-my-logo "CIB Mango Tree" gold --filled --no-color`)
-Ascii tree was generated with: https://www.asciiart.eu/image-to-ascii
-"""
 from rich import print
 from rich.panel import Panel
 
@@ -57,3 +52,10 @@ _FOOTER: str = Panel.fit(
        ╲ ===== ╱  ╱[/red]
 """
 )
+
+"""
+Notes:
+Logo generated with: https://github.com/shinshin86/oh-my-logo
+(used as: `npx oh-my-logo "CIB Mango Tree" gold --filled --no-color`)
+Ascii tree was generated with: https://www.asciiart.eu/image-to-ascii
+"""

--- a/components/splash.py
+++ b/components/splash.py
@@ -1,4 +1,5 @@
 from rich import print
+from rich.console import Console
 from rich.panel import Panel
 
 from meta import get_version
@@ -6,16 +7,57 @@ from terminal_tools import clear_terminal, wait_for_key
 
 
 def splash():
+    console = Console()
+
+    # Calculate exact width thresholds for each logo size
+    # Measured from actual ASCII art content + Rich Panel borders/padding
+    BIG_LOGO_WIDTH = 102  # Big logo longest line
+    SMALL_LOGO_WIDTH = 78  # Small logo longest line
+    PANEL_PADDING = 4  # Rich Panel border + padding (2 chars each side)
+
+    BIG_THRESHOLD = BIG_LOGO_WIDTH + PANEL_PADDING  # 106 chars
+    SMALL_THRESHOLD = SMALL_LOGO_WIDTH + PANEL_PADDING  # 82 chars
+
     clear_terminal()
-    print(_ASCII_LOGO)
+
+    # Three-tier adaptive logo display
+    if console.size.width < SMALL_THRESHOLD:
+        print(_LOGO_MINI)  # Very narrow terminals
+    elif console.size.width < BIG_THRESHOLD:
+        print(_ASCII_LOGO_SMALL)  # Medium terminals
+    else:
+        print(_ASCII_LOGO_BIG)  # Wide terminals
+
     print(_ASCII_TREE)
     print("")
     wait_for_key(True)
 
 
 _VERSION = f"[dim]{get_version() or 'development version'}[/dim]"
+_TITLE = "A Civic Tech DC Project"
 
-_ASCII_LOGO = Panel.fit(
+_LOGO_MINI = Panel.fit(
+    """[orange1 bold]
+    CIB MANGO TREE
+    [/orange1 bold]""",
+    title=_TITLE,
+    title_align="center",
+    subtitle=_VERSION,
+)
+
+_ASCII_LOGO_SMALL = Panel.fit(
+    """[orange1]
+   ____ ___ ____    __  __                           _____              
+  / ___|_ _| __ )  |  \/  | __ _ _ __   __ _  ___   |_   _| __ ___  ___ 
+ | |    | ||  _ \  | |\/| |/ _` | '_ \ / _` |/ _ \    | || '__/ _ \/ _ \\
+ | |___ | || |_) | | |  | | (_| | | | | (_| | (_) |   | || | |  __/  __/
+  \____|___|____/  |_|  |_|\__,_|_| |_|\__, |\___/    |_||_|  \___|\___|
+                                       |___/[/orange1]""",
+    title=_TITLE,
+    subtitle=_VERSION,
+)
+
+_ASCII_LOGO_BIG = Panel.fit(
     """[orange1]
   ██████╗ ██╗ ██████╗      ███╗   ███╗  █████╗  ███╗   ██╗  ██████╗   ██████╗      ████████╗ ██████╗  ███████╗ ███████╗
  ██╔════╝ ██║ ██╔══██╗     ████╗ ████║ ██╔══██╗ ████╗  ██║ ██╔════╝  ██╔═══██╗     ╚══██╔══╝ ██╔══██╗ ██╔════╝ ██╔════╝
@@ -23,7 +65,7 @@ _ASCII_LOGO = Panel.fit(
  ██║      ██║ ██╔══██╗     ██║╚██╔╝██║ ██╔══██║ ██║╚██╗██║ ██║   ██║ ██║   ██║        ██║    ██╔══██╗ ██╔══╝   ██╔══╝
  ╚██████╗ ██║ ██████╔╝     ██║ ╚═╝ ██║ ██║  ██║ ██║ ╚████║ ╚██████╔╝ ╚██████╔╝        ██║    ██║  ██║ ███████╗ ███████╗
   ╚═════╝ ╚═╝ ╚═════╝      ╚═╝     ╚═╝ ╚═╝  ╚═╝ ╚═╝  ╚═══╝  ╚═════╝   ╚═════╝         ╚═╝    ╚═╝  ╚═╝ ╚══════╝ ╚══════╝[/orange1]""",
-    title="A Civic Tech DC Project",
+    title=_TITLE,
     subtitle=_VERSION,
 )
 

--- a/components/splash.py
+++ b/components/splash.py
@@ -1,18 +1,34 @@
+from rich import print
+from rich.panel import Panel
+
 from meta import get_version
 from terminal_tools import clear_terminal, wait_for_key
 
 
 def splash():
     clear_terminal()
-    print(_ascii_splash)
-    print("")
-    print(f"{get_version() or '<development version>'}")
+    print(_ASCII_LOGO)
+    print(_ASCII_TREE)
     print("")
     wait_for_key(True)
 
 
-_ascii_splash: str = """
-       -..*+:..-
+_VERSION = f"[dim]{get_version() or 'development version'}[/dim]"
+
+_ASCII_LOGO = Panel.fit(
+    """[orange1]
+  ██████╗ ██╗ ██████╗      ███╗   ███╗  █████╗  ███╗   ██╗  ██████╗   ██████╗      ████████╗ ██████╗  ███████╗ ███████╗
+ ██╔════╝ ██║ ██╔══██╗     ████╗ ████║ ██╔══██╗ ████╗  ██║ ██╔════╝  ██╔═══██╗     ╚══██╔══╝ ██╔══██╗ ██╔════╝ ██╔════╝
+ ██║      ██║ ██████╔╝     ██╔████╔██║ ███████║ ██╔██╗ ██║ ██║  ███╗ ██║   ██║        ██║    ██████╔╝ █████╗   █████╗
+ ██║      ██║ ██╔══██╗     ██║╚██╔╝██║ ██╔══██║ ██║╚██╗██║ ██║   ██║ ██║   ██║        ██║    ██╔══██╗ ██╔══╝   ██╔══╝
+ ╚██████╗ ██║ ██████╔╝     ██║ ╚═╝ ██║ ██║  ██║ ██║ ╚████║ ╚██████╔╝ ╚██████╔╝        ██║    ██║  ██║ ███████╗ ███████╗
+  ╚═════╝ ╚═╝ ╚═════╝      ╚═╝     ╚═╝ ╚═╝  ╚═╝ ╚═╝  ╚═══╝  ╚═════╝   ╚═════╝         ╚═╝    ╚═╝  ╚═╝ ╚══════╝ ╚══════╝[/orange1]""",
+    title="A Civic Tech DC Project",
+    subtitle=_VERSION,
+)
+
+_ASCII_TREE: str = """
+        -..*+:..-.
        -.=-+%@%##+-=.-
     = =:*%:...=:..=@*:+ =
   :: -:=#==#*=:::-=-...-:::
@@ -26,14 +42,17 @@ _ascii_splash: str = """
             @@#=
             @@%
             @@@
-
- C I B   M A N G O   T R E E
-
-   A Civic Tech DC Project
-
-       ╱ * * *  ╱ ╲
-       ╲ ===== ╱  ╱
 """
+
+_FOOTER: str = Panel.fit(
+    """
+  A Civic Tech DC Project
+[red]
+       ╱ * * *  ╱ ╲
+       ╲ ===== ╱  ╱[/red]
+"""
+)
+
 """
 I generated this using https://www.asciiart.eu/image-to-ascii
 """

--- a/components/splash.py
+++ b/components/splash.py
@@ -1,3 +1,8 @@
+"""
+Logo generated with: https://github.com/shinshin86/oh-my-logo
+(used as: `npx oh-my-logo "CIB Mango Tree" gold --filled --no-color`)
+Ascii tree was generated with: https://www.asciiart.eu/image-to-ascii
+"""
 from rich import print
 from rich.panel import Panel
 
@@ -52,7 +57,3 @@ _FOOTER: str = Panel.fit(
        ╲ ===== ╱  ╱[/red]
 """
 )
-
-"""
-I generated this using https://www.asciiart.eu/image-to-ascii
-"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ starlette==0.47.1
 uvicorn==0.34.3
 a2wsgi==1.10.10
 python-json-logger==2.0.7
+rich==14.0.0

--- a/terminal_tools/__init__.py
+++ b/terminal_tools/__init__.py
@@ -6,7 +6,7 @@ from .utils import (
     enable_windows_ansi_support,
     open_directory_explorer,
     print_ascii_table,
-    print_data_frame,
     print_dialog_section_title,
+    smart_print_data_frame,
     wait_for_key,
 )

--- a/terminal_tools/__init__.py
+++ b/terminal_tools/__init__.py
@@ -7,5 +7,6 @@ from .utils import (
     open_directory_explorer,
     print_ascii_table,
     print_data_frame,
+    print_dialog_section_title,
     wait_for_key,
 )

--- a/terminal_tools/__init__.py
+++ b/terminal_tools/__init__.py
@@ -6,5 +6,6 @@ from .utils import (
     enable_windows_ansi_support,
     open_directory_explorer,
     print_ascii_table,
+    print_data_frame,
     wait_for_key,
 )

--- a/terminal_tools/inception.py
+++ b/terminal_tools/inception.py
@@ -5,7 +5,7 @@ instances. Each `Scope` instance represents a block of text that are buffered
 in memory and printed to the terminal at each refresh.
 """
 
-from terminal_tools import print_dialog_section_title
+# from terminal_tools import print_dialog_section_title
 
 from .utils import clear_terminal
 
@@ -36,7 +36,7 @@ class Scope:
         self.text = text
 
     def print(self):
-        print_dialog_section_title(self.text)
+        print(self.text)
 
     def refresh(self):
         """Clear the terminal and repaint with every scope up and including to this one"""

--- a/terminal_tools/inception.py
+++ b/terminal_tools/inception.py
@@ -5,6 +5,8 @@ instances. Each `Scope` instance represents a block of text that are buffered
 in memory and printed to the terminal at each refresh.
 """
 
+from terminal_tools import print_dialog_section_title
+
 from .utils import clear_terminal
 
 
@@ -34,7 +36,7 @@ class Scope:
         self.text = text
 
     def print(self):
-        print(self.text)
+        print_dialog_section_title(self.text)
 
     def refresh(self):
         """Clear the terminal and repaint with every scope up and including to this one"""

--- a/terminal_tools/utils.py
+++ b/terminal_tools/utils.py
@@ -4,6 +4,7 @@ import sys
 
 import polars as pl
 from rich.console import Console
+from rich.style import Style
 from rich.table import Table
 
 
@@ -194,6 +195,9 @@ def print_ascii_table(
     print(border_row("└─", "─┴─", "─┘"))
 
 
+console = Console()
+
+
 def print_data_frame(data_frame, title: str, apply_color: str):
     # see: https://rich.readthedocs.io/en/stable/appendix/colors.html
     DF_COLORS = [
@@ -224,6 +228,10 @@ def print_data_frame(data_frame, title: str, apply_color: str):
         clr = row_clr if apply_color == "row-wise" else None
         table.add_row(*row, style=clr)
 
-    console = Console()
-
     console.print(table)
+
+
+def print_dialog_section_title(print_str):
+    mango_style = Style(color="#F3921E", bold=True)
+
+    console.print(print_str, style=mango_style)

--- a/terminal_tools/utils.py
+++ b/terminal_tools/utils.py
@@ -382,20 +382,40 @@ def print_data_frame_summary(
 
 
 def smart_print_data_frame(
-    data_frame,
+    data_frame: pl.DataFrame,
     title: str,
-    apply_color: str = "column_data_type",
+    apply_color: str | None = "column_data_type",
     smart_print: bool = True,
-    caption: str = None,
-):
-    """Smart dataframe printing - uses summary for wide tables, full display for narrow ones
+    caption: str | None = None,
+) -> None:
+    """Smart dataframe printing with adaptive display based on terminal width.
+
+    Automatically chooses between full table display and summary view based on terminal
+    width and number of columns. Provides Rich-styled tables with configurable coloring.
 
     Args:
         data_frame: Polars DataFrame to display
-        title: Title for the table
-        apply_color: Color mode ("column_data_type", "column-wise", "row-wise", or None)
-        smart_print: If True, uses adaptive display (summary vs full). If False, always uses full display.
-        caption: Optional caption text to display below the table
+        title: Title text to display above the table
+        apply_color: Color mode for the table display:
+            - "column_data_type": Colors columns based on their Polars data types
+            - "column-wise": Cycles through colors for each column
+            - "row-wise": Cycles through colors for each row
+            - None: No coloring (plain black and white display)
+        smart_print: Controls adaptive display behavior:
+            - True: Uses summary view for wide tables (>8 cols or narrow terminal)
+            - False: Always uses full table display regardless of width
+        caption: Optional caption text displayed below the table
+
+    Display Logic:
+        - If smart_print=False: Always shows full table
+        - If smart_print=True and (>8 columns OR estimated column width <12):
+          Shows summary with column info, data types, and examples
+        - Otherwise: Shows full table with all data
+
+    Examples:
+        >>> smart_print_data_frame(df, "My Data", apply_color=None)
+        >>> smart_print_data_frame(df, "Analysis Results", caption="Processing complete")
+        >>> smart_print_data_frame(df, "Wide Dataset", smart_print=False)
     """
     if not smart_print:
         # Always use full dataframe display when smart_print is disabled

--- a/terminal_tools/utils.py
+++ b/terminal_tools/utils.py
@@ -198,7 +198,7 @@ def print_ascii_table(
 console = Console()
 
 
-def print_data_frame(data_frame, title: str, apply_color: str):
+def print_data_frame(data_frame, title: str, apply_color: str, caption: str = None):
     # Mapping Polars data types to Rich colors (medium brightness)
     # see: https://rich.readthedocs.io/en/stable/appendix/colors.html
     POLARS_TYPE_COLORS = {
@@ -275,7 +275,7 @@ def print_data_frame(data_frame, title: str, apply_color: str):
     # Convert non-string columns to strings for display
     data_frame = data_frame.with_columns(pl.exclude(pl.String).cast(str))
 
-    table = Table(title=title)
+    table = Table(title=title, caption=caption)
 
     # Add columns with appropriate coloring and width limits
     for i, col in enumerate(data_frame.columns):
@@ -332,7 +332,7 @@ def print_data_frame(data_frame, title: str, apply_color: str):
 
 
 def print_data_frame_summary(
-    data_frame, title: str, apply_color: str = "column_data_type"
+    data_frame, title: str, apply_color: str = "column_data_type", caption: str = None
 ):
     """Print a summary table for dataframes with many columns"""
     from preprocessing.series_semantic import infer_series_semantic
@@ -378,7 +378,7 @@ def print_data_frame_summary(
     )
 
     # Print with specified coloring mode
-    print_data_frame(summary_df, title, apply_color)
+    print_data_frame(summary_df, title, apply_color, caption)
 
 
 def smart_print_data_frame(
@@ -386,6 +386,7 @@ def smart_print_data_frame(
     title: str,
     apply_color: str = "column_data_type",
     smart_print: bool = True,
+    caption: str = None,
 ):
     """Smart dataframe printing - uses summary for wide tables, full display for narrow ones
 
@@ -394,10 +395,11 @@ def smart_print_data_frame(
         title: Title for the table
         apply_color: Color mode ("column_data_type", "column-wise", "row-wise", or None)
         smart_print: If True, uses adaptive display (summary vs full). If False, always uses full display.
+        caption: Optional caption text to display below the table
     """
     if not smart_print:
         # Always use full dataframe display when smart_print is disabled
-        print_data_frame(data_frame, title, apply_color)
+        print_data_frame(data_frame, title, apply_color, caption)
         return
 
     # Smart adaptive logic
@@ -414,9 +416,10 @@ def smart_print_data_frame(
             data_frame,
             title + " (Dataset has a large nr. of columns, showing summary instead)",
             apply_color,
+            caption,
         )
     else:
-        print_data_frame(data_frame, title, apply_color)
+        print_data_frame(data_frame, title, apply_color, caption)
 
 
 def print_dialog_section_title(print_str):


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This replaces #185, reopening from a branch on this repository with some updates in order to trigger docs preview and make tests pass.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the CLI uses built-in print and custom methods

Issue Number: #172 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

1. Add `smart_print_data_frame()` that uses `rich.Table` for better printing of data frames, replaces `print_ascii_table`
    1. can color-code columns, rows or columns based on data types
    1. uses smarter column width setting
1. Add three different logo sizes for welcome screen (`splash.py`) and use them adaptively based on terminal width. See below:

### Big logo

<img width="2232" height="1000" alt="image" src="https://github.com/user-attachments/assets/f419a067-a29c-4885-bd0f-d4b91bbc18ec" />

### Small logo

<img width="1400" height="364" alt="image" src="https://github.com/user-attachments/assets/3acd1429-3cc3-424d-99e3-1f7b36b396d5" />

### Mini Logo

<img width="568" height="216" alt="image" src="https://github.com/user-attachments/assets/085dd2f5-8946-4732-9a05-ca3d8e09e8a4" />


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
