### PR TITLE
[bugfix] Add `pythonjsonlogger` to hidden imports

### DIFF
--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -71,6 +71,8 @@ a = Analysis(
         'mdit_py_plugins',
         'mdurl',
         'uc_micro',
+        'pythonjsonlogger',
+        'pythonjsonlogger.jsonlogger',
     ],  # Include any imports that PyInstaller might miss
     hookspath=[],
     runtime_hooks=[],


### PR DESCRIPTION
Add `pythonjsonlogger` and `pythonjsonlogger.jsonlogger` to hidden imports in `pyinstaller.spec`

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The app does not launch import starting it.

Issue Number: #197

## What is the new behavior?

## Does this introduce a breaking change?

- [ ] Yes
- [x] No